### PR TITLE
chore: small nit fixes for unused logger, compiler check for interface

### DIFF
--- a/cmd/dra-example-controller/driver.go
+++ b/cmd/dra-example-controller/driver.go
@@ -45,7 +45,7 @@ type driver struct {
 	gpu       *gpudriver
 }
 
-var _ controller.Driver = (*driver)(nil)
+var _ controller.Driver = &driver{}
 
 func NewDriver(config *Config) *driver {
 	return &driver{

--- a/cmd/dra-example-kubeletplugin/cdi.go
+++ b/cmd/dra-example-kubeletplugin/cdi.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
-
 	cdiapi "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	cdispec "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	nascrd "github.com/kubernetes-sigs/dra-example-driver/api/example.com/resource/gpu/nas/v1alpha1"
@@ -36,7 +34,6 @@ const (
 )
 
 type CDIHandler struct {
-	logger   *logrus.Logger
 	registry cdiapi.Registry
 }
 
@@ -50,12 +47,7 @@ func NewCDIHandler(config *Config) (*CDIHandler, error) {
 		return nil, fmt.Errorf("unable to refresh the CDI registry: %v", err)
 	}
 
-	logger := logrus.New()
-	logger.Out = os.Stdout
-	logger.Level = logrus.DebugLevel
-
 	handler := &CDIHandler{
-		logger:   logger,
 		registry: registry,
 	}
 

--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -28,6 +28,8 @@ import (
 	nasclient "github.com/kubernetes-sigs/dra-example-driver/api/example.com/resource/gpu/nas/v1alpha1/client"
 )
 
+var _ drapbv1.NodeServer = &driver{}
+
 type driver struct {
 	nascrd    *nascrd.NodeAllocationState
 	nasclient *nasclient.Client

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.4
 	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
@@ -89,6 +88,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect


### PR DESCRIPTION
This PR contains a set of small nit fixes that I made when implementing my own DRA resource driver based on your great KubeCon Europe 2023 talk:

- Remove unused logrus logger from CDIHandler and its direct dependency
- Add a compiler check for the driver that implements the DRA NodeServer interface as well as the driver that implements the  DRA controller
- ~~Rename misleading function that only returns allocated devices without actually allocating devices~~