### PR TITLE
fix: remove noop code from UnsuitableNode for GPU driver

### DIFF
--- a/cmd/dra-example-controller/gpu.go
+++ b/cmd/dra-example-controller/gpu.go
@@ -100,7 +100,6 @@ func (g *gpudriver) UnsuitableNode(crd *nascrd.NodeAllocationState, pod *corev1.
 		}
 
 		g.PendingAllocatedClaims.Set(claimUID, potentialNode, allocatedDevices)
-		crd.Spec.AllocatedClaims[claimUID] = allocatedDevices
 	}
 
 	return nil


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/dra-example-driver/pull/1#discussion_r1183293196

There is no code path for the NAS CRD update when the UnsuitableNodes API is called.
The AllocatedClaims field of NAS CRD is set and updated when the Allocate API is called, so we don't need to set it in UnsuitableNode for GPU driver.

https://github.com/kubernetes-sigs/dra-example-driver/blob/d685a0bb048efbb69d7253ae0658e3d2eac1127e/cmd/dra-example-controller/gpu.go#L54

https://github.com/kubernetes-sigs/dra-example-driver/blob/d685a0bb048efbb69d7253ae0658e3d2eac1127e/cmd/dra-example-controller/driver.go#L139-L142