### PR TITLE
Ignore type conversion safety

### DIFF
--- a/cmd/dra-example-controller/driver.go
+++ b/cmd/dra-example-controller/driver.go
@@ -125,7 +125,8 @@ func (d driver) Allocate(ctx context.Context, claim *resourcev1.ResourceClaim, c
 	}
 
 	var onSuccess OnSuccessCallback
-	classParams := classParameters.(*gpucrd.DeviceClassParametersSpec)
+	classParams, _ := classParameters.(*gpucrd.DeviceClassParametersSpec)
+
 	switch claimParams := claimParameters.(type) {
 	case *gpucrd.GpuClaimParametersSpec:
 		onSuccess, err = d.gpu.Allocate(crd, claim, claimParams, class, classParams, selectedNode)

--- a/cmd/dra-example-controller/gpu.go
+++ b/cmd/dra-example-controller/gpu.go
@@ -76,7 +76,7 @@ func (g *gpudriver) UnsuitableNode(crd *nascrd.NodeAllocationState, pod *corev1.
 	allocated := g.allocate(crd, pod, gpucas, allcas, potentialNode)
 	for _, ca := range gpucas {
 		claimUID := string(ca.Claim.UID)
-		claimParams := ca.ClaimParameters.(*gpucrd.GpuClaimParametersSpec)
+		claimParams, _ := ca.ClaimParameters.(*gpucrd.GpuClaimParametersSpec)
 
 		if claimParams.Count != len(allocated[claimUID]) {
 			for _, ca := range allcas {
@@ -136,7 +136,7 @@ func (g *gpudriver) allocate(crd *nascrd.NodeAllocationState, pod *corev1.Pod, g
 			continue
 		}
 
-		claimParams := ca.ClaimParameters.(*gpucrd.GpuClaimParametersSpec)
+		claimParams, _ := ca.ClaimParameters.(*gpucrd.GpuClaimParametersSpec)
 		var devices []string
 		for i := 0; i < claimParams.Count; i++ {
 			for _, device := range available {


### PR DESCRIPTION
Needed to enable linters #12 , typeassert complains about skipping type conversion return value not checked, let's skip them explicitly.