### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+name: Run lint
+
+on: [ push, pull_request ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: update vendor
+      run: go mod vendor
+    - name: Lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        args: -v --timeout 5m
+        skip-cache: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,30 @@
+name: Run tests
+
+on: [ push, pull_request ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        version: ['1.20' ]
+        platform: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.version }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Update vendor modules
+      run: go mod vendor
+    - name: Build
+      run: make PREFIX=artifacts cmds
+    - name: List binaries
+      run: ls -al artifacts/
+    # no tests yet
+    # - name: Test
+    #   run: go test -v -race ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,15 @@
+# please keep this alphabetized
+linters:
+  enable:
+    - asciicheck
+    - forcetypeassert
+    - gocritic
+    - godot
+    - gofmt
+    - goimports
+    - misspell
+    - stylecheck
+
+run:
+  tests: true
+  timeout: 1m


### PR DESCRIPTION
Implements #12 . Two linters are disabled ATM, plenty of complaints, I'll create an issue to fix them and then we can enable gocritic and revive linters.
Apologies, this includes https://github.com/kubernetes-sigs/dra-example-driver/pull/13 so please review that one first, otherwise linters complain.