### PR TITLE
Ensure that the DRA controller only gets deployed on control plane nodes

### DIFF
--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -29,7 +29,8 @@ controller:
   priorityClassName: "system-node-critical"
   podAnnotations: {}
   podSecurityContext: {}
-  nodeSelector: {}
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
   tolerations:
   - key: node-role.kubernetes.io/master
     operator: Exists


### PR DESCRIPTION
The taint was set previously (meaning it COULD be scheduled on control plan nodes), but without the nodeSelector it is not guaranteed to be.