### PR TITLE
Use the same base image as test/e2e/dra does

### DIFF
--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -35,10 +35,6 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 # From https://github.com/kubernetes/kubernetes/tags
 : ${KIND_K8S_TAG:="v1.27.1"}
 
-# The containerd tag to patch the kind image with
-# From https://github.com/kind-ci/containerd-nightlies/releases
-: ${KIND_CONTAINERD_TAG:="containerd-1.7.0-79-g2503bef58"}
-
 # The name of the kind cluster to create
 : ${KIND_CLUSTER_NAME:="${DRIVER_NAME}-cluster"}
 
@@ -46,8 +42,10 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 : ${KIND_CLUSTER_CONFIG_PATH:="${SCRIPTS_DIR}/kind-cluster-config.yaml"}
 
 # The derived name of the driver image to build
-DRIVER_IMAGE="${DRIVER_IMAGE_REGISTRY}/${DRIVER_IMAGE_NAME}:${DRIVER_IMAGE_TAG}"
+: ${DRIVER_IMAGE:="${DRIVER_IMAGE_REGISTRY}/${DRIVER_IMAGE_NAME}:${DRIVER_IMAGE_TAG}"}
 
 # The derived name of the kind image to build
-KIND_IMAGE="kindest/node:${KIND_K8S_TAG}-${KIND_CONTAINERD_TAG}"
+: ${KIND_IMAGE_BASE_TAG:="v20230515-01914134-containerd_v1.7.1"}
+: ${KIND_IMAGE_BASE:="gcr.io/k8s-staging-kind/base:${KIND_IMAGE_BASE_TAG}"}
+: ${KIND_IMAGE:="kindest/node:${KIND_K8S_TAG}-${KIND_IMAGE_BASE_TAG}"}
 

--- a/demo/scripts/kind-cluster-config.yaml
+++ b/demo/scripts/kind-cluster-config.yaml
@@ -2,6 +2,12 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   DynamicResourceAllocation: true
+containerdConfigPatches:
+# Enable CDI as described in
+# https://github.com/container-orchestrated-devices/container-device-interface#containerd-configuration
+- |-
+  [plugins."io.containerd.grpc.v1.cri"]
+    enable_cdi = true
 nodes:
 - role: control-plane
   kubeadmConfigPatches:


### PR DESCRIPTION
This PR https://github.com/kubernetes/kubernetes/pull/118030 introduced the use of a custom kind base image with containerd preinstalled (instead of building one from scratch).

We now use this same base image for our kind cluster as well.