### PR TITLE
Kubelet plugin switch to v1alpha3 api

### DIFF
--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -220,7 +220,7 @@ func (s *DeviceState) syncPreparedDevicesFromCRDSpec(spec *nascrd.NodeAllocation
 	for claim, devices := range spec.PreparedClaims {
 		switch devices.Type() {
 		case nascrd.GpuDeviceType:
-			prepared[claim] = &PreparedDevices{}
+			prepared[claim] = &PreparedDevices{Gpu: &PreparedGpus{}}
 			for _, d := range devices.Gpu.Devices {
 				prepared[claim].Gpu.Devices = append(prepared[claim].Gpu.Devices, gpus[d.UUID].GpuInfo)
 			}


### PR DESCRIPTION
This is an incremental PR, that is build on top of #24 because it needs 1.28 K8s SRC. CR can cover just the last commit with src/dra-example-kubeletplugin changess.