### PR TITLE
pass ctx objects from cmd Run func down to the kubeClients

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@
 linters:
   enable:
     - asciicheck
+    - contextcheck
     - forcetypeassert
     - gocritic
     - godot

--- a/api/example.com/resource/gpu/nas/v1alpha1/client/client.go
+++ b/api/example.com/resource/gpu/nas/v1alpha1/client/client.go
@@ -38,20 +38,20 @@ func New(nas *nascrd.NodeAllocationState, client nasclient.NasV1alpha1Interface)
 	}
 }
 
-func (c *Client) GetOrCreate() error {
-	err := c.Get()
+func (c *Client) GetOrCreate(ctx context.Context) error {
+	err := c.Get(ctx)
 	if err == nil {
 		return nil
 	}
 	if errors.IsNotFound(err) {
-		return c.Create()
+		return c.Create(ctx)
 	}
 	return err
 }
 
-func (c *Client) Create() error {
+func (c *Client) Create(ctx context.Context) error {
 	crd := c.nas.DeepCopy()
-	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Create(context.TODO(), crd, metav1.CreateOptions{})
+	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Create(ctx, crd, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -59,20 +59,20 @@ func (c *Client) Create() error {
 	return nil
 }
 
-func (c *Client) Delete() error {
+func (c *Client) Delete(ctx context.Context) error {
 	deletePolicy := metav1.DeletePropagationForeground
 	deleteOptions := metav1.DeleteOptions{PropagationPolicy: &deletePolicy}
-	err := c.client.NodeAllocationStates(c.nas.Namespace).Delete(context.TODO(), c.nas.Name, deleteOptions)
+	err := c.client.NodeAllocationStates(c.nas.Namespace).Delete(ctx, c.nas.Name, deleteOptions)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 	return nil
 }
 
-func (c *Client) Update(spec *nascrd.NodeAllocationStateSpec) error {
+func (c *Client) Update(ctx context.Context, spec *nascrd.NodeAllocationStateSpec) error {
 	crd := c.nas.DeepCopy()
 	crd.Spec = *spec
-	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Update(context.TODO(), crd, metav1.UpdateOptions{})
+	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Update(ctx, crd, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -80,10 +80,10 @@ func (c *Client) Update(spec *nascrd.NodeAllocationStateSpec) error {
 	return nil
 }
 
-func (c *Client) UpdateStatus(status string) error {
+func (c *Client) UpdateStatus(ctx context.Context, status string) error {
 	crd := c.nas.DeepCopy()
 	crd.Status = status
-	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Update(context.TODO(), crd, metav1.UpdateOptions{})
+	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Update(ctx, crd, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -91,8 +91,8 @@ func (c *Client) UpdateStatus(status string) error {
 	return nil
 }
 
-func (c *Client) Get() error {
-	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Get(context.TODO(), c.nas.Name, metav1.GetOptions{})
+func (c *Client) Get(ctx context.Context) error {
+	crd, err := c.client.NodeAllocationStates(c.nas.Namespace).Get(ctx, c.nas.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/dra-example-controller/driver.go
+++ b/cmd/dra-example-controller/driver.go
@@ -32,7 +32,6 @@ import (
 )
 
 const (
-	DriverName     = gpucrd.GroupName
 	DriverAPIGroup = gpucrd.GroupName
 )
 
@@ -109,7 +108,7 @@ func (d driver) Allocate(ctx context.Context, claim *resourcev1.ResourceClaim, c
 	crd := nascrd.NewNodeAllocationState(crdconfig)
 
 	client := nasclient.New(crd, d.clientset.NasV1alpha1())
-	err := client.Get()
+	err := client.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving node specific Gpu CRD: %v", err)
 	}
@@ -139,7 +138,7 @@ func (d driver) Allocate(ctx context.Context, claim *resourcev1.ResourceClaim, c
 		return nil, fmt.Errorf("unable to allocate devices on node '%v': %v", selectedNode, err)
 	}
 
-	err = client.Update(&crd.Spec)
+	err = client.Update(ctx, &crd.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("error updating NodeAllocationState CRD: %v", err)
 	}
@@ -165,7 +164,7 @@ func (d driver) Deallocate(ctx context.Context, claim *resourcev1.ResourceClaim)
 	crd := nascrd.NewNodeAllocationState(crdconfig)
 
 	client := nasclient.New(crd, d.clientset.NasV1alpha1())
-	err := client.Get()
+	err := client.Get(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving node specific Gpu CRD: %v", err)
 	}
@@ -191,7 +190,7 @@ func (d driver) Deallocate(ctx context.Context, claim *resourcev1.ResourceClaim)
 
 	delete(crd.Spec.AllocatedClaims, string(claim.UID))
 
-	err = client.Update(&crd.Spec)
+	err = client.Update(ctx, &crd.Spec)
 	if err != nil {
 		return fmt.Errorf("error updating NodeAllocationState CRD: %v", err)
 	}
@@ -225,7 +224,7 @@ func (d driver) unsuitableNode(ctx context.Context, pod *corev1.Pod, allcas []*c
 	crd := nascrd.NewNodeAllocationState(crdconfig)
 
 	client := nasclient.New(crd, d.clientset.NasV1alpha1())
-	err := client.Get()
+	err := client.Get(ctx)
 	if err != nil {
 		for _, ca := range allcas {
 			ca.UnsuitableNodes = append(ca.UnsuitableNodes, potentialNode)

--- a/cmd/dra-example-kubeletplugin/cdi.go
+++ b/cmd/dra-example-kubeletplugin/cdi.go
@@ -22,6 +22,7 @@ import (
 
 	cdiapi "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	cdispec "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+
 	nascrd "sigs.k8s.io/dra-example-driver/api/example.com/resource/gpu/nas/v1alpha1"
 )
 

--- a/cmd/set-nas-status/main.go
+++ b/cmd/set-nas-status/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -82,8 +81,8 @@ func newApp() *cli.App {
 			}
 			return loggingConfig.Apply()
 		},
-		Action: func(*cli.Context) error {
-			ctx := context.Background()
+		Action: func(c *cli.Context) error {
+			ctx := c.Context
 			clientSets, err := kubeClientConfig.NewClientSets()
 			if err != nil {
 				return fmt.Errorf("create client: %v", err)
@@ -96,11 +95,11 @@ func newApp() *cli.App {
 
 			client := nasclient.New(nascr, clientSets.Example.NasV1alpha1())
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				err := client.GetOrCreate()
+				err := client.GetOrCreate(ctx)
 				if err != nil {
 					return err
 				}
-				return client.UpdateStatus(status)
+				return client.UpdateStatus(ctx, status)
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixing how the ctx object is initalised and passed down the call stack in the demo code

This PR fixes the following linting issues

```
golangci-lint run ./...
cmd/dra-example-controller/driver.go:112:19: Function `Get` should pass the context parameter (contextcheck)
        err := client.Get()
                         ^
cmd/dra-example-controller/driver.go:142:21: Function `Update` should pass the context parameter (contextcheck)
        err = client.Update(&crd.Spec)
                           ^
cmd/dra-example-controller/driver.go:168:19: Function `Get` should pass the context parameter (contextcheck)
        err := client.Get()
                         ^
cmd/dra-example-controller/driver.go:194:21: Function `Update` should pass the context parameter (contextcheck)
        err = client.Update(&crd.Spec)
                           ^
cmd/dra-example-controller/driver.go:228:19: Function `Get` should pass the context parameter (contextcheck)
        err := client.Get()
                         ^
```