### PR TITLE
make .gitignore only ignore binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 vendor/
 [._]*.sw[a-p]
 
-dra-example-controller
-dra-example-kubeletplugin
-set-nas-status
+./dra-example-controller
+./dra-example-kubeletplugin
+./set-nas-status


### PR DESCRIPTION
#26 broke .gitignore, it now ignores `cmd/<$binarry>/` source as well as ./$<binary>. This fixes the excessive ignore.