### PR TITLE
Fix null dereference in nas-set-status

### DIFF
--- a/cmd/set-nas-status/main.go
+++ b/cmd/set-nas-status/main.go
@@ -42,9 +42,11 @@ func newApp() *cli.App {
 		status string
 
 		kubeClientConfig flags.KubeClientConfig
-		loggingConfig    flags.LoggingConfig
+		loggingConfig    *flags.LoggingConfig
 		nasConfig        flags.NasConfig
 	)
+
+	loggingConfig = flags.NewLoggingConfig()
 
 	flags := []cli.Flag{
 		&cli.StringFlag{
@@ -65,6 +67,7 @@ func newApp() *cli.App {
 			EnvVars: []string{"STATUS"},
 		},
 	}
+
 	flags = append(flags, kubeClientConfig.Flags()...)
 	flags = append(flags, loggingConfig.Flags()...)
 	flags = append(flags, nasConfig.Flags()...)


### PR DESCRIPTION
Currently when init container for kubelet plugin tries to start, it fails with SEGFAULT when it tries to add logging flags because the pointer in LoggingConfig is not initialized.

This fixes it.