### PR TITLE
Rename nodePrepareResources to nodePrepareResource

### DIFF
--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -104,13 +104,13 @@ func (d *driver) NodePrepareResources(ctx context.Context, req *drapbv1.NodePrep
 	// should be done outside of the loop, for instance updating the CR could
 	// be done once after all HW was prepared.
 	for _, claim := range req.Claims {
-		preparedResources.Claims[claim.Uid] = d.nodePrepareResources(ctx, claim)
+		preparedResources.Claims[claim.Uid] = d.nodePrepareResource(ctx, claim)
 	}
 
 	return preparedResources, nil
 }
 
-func (d *driver) nodePrepareResources(ctx context.Context, claim *drapbv1.Claim) *drapbv1.NodePrepareResourceResponse {
+func (d *driver) nodePrepareResource(ctx context.Context, claim *drapbv1.Claim) *drapbv1.NodePrepareResourceResponse {
 	var err error
 	var prepared []string
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION
This change renames the private function for preparing a single resource claim to nodePrepareResource instead of nodePrepareResources. This avoids confusion with the NodePrepareResources call added in the v1alpha3 API.