### PR TITLE
moq was using golang 1.23 for latest

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GOLANG_VERSION ?= 1.22.2
+GOLANG_VERSION ?= 1.22.6
 
 DRIVER_NAME := dra-example-driver
 MODULE := sigs.k8s.io/$(DRIVER_NAME)

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -18,6 +18,6 @@ RUN go install github.com/gordonklaus/ineffassign@latest && \
     go install github.com/client9/misspell/cmd/misspell@latest
 
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
-RUN go install github.com/matryer/moq@latest
+RUN go install github.com/matryer/moq@v0.4.0
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 RUN go install k8s.io/code-generator/cmd/client-gen@v0.29.2


### PR DESCRIPTION
When I tried to run the driver, I was getting failures for two reasons.

1) go install github.com/matryer/moq@latest picks up a release that requires golang 1.23.
2) using the previous release 0.4.0 requires at least golang 1.22.6.

Updated the make file to use 1.22.6 and clamped moq to a fix version that does not require golang 1.23 yet.