### PR TITLE
Update demo specs to replace sleep command with one that catches SIGTERM

### DIFF
--- a/demo/gpu-test1.yaml
+++ b/demo/gpu-test1.yaml
@@ -33,7 +33,7 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpu
@@ -54,7 +54,7 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpu

--- a/demo/gpu-test2.yaml
+++ b/demo/gpu-test2.yaml
@@ -35,7 +35,7 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: gpus

--- a/demo/gpu-test3.yaml
+++ b/demo/gpu-test3.yaml
@@ -31,14 +31,14 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu
   - name: ctr1
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu

--- a/demo/gpu-test4.yaml
+++ b/demo/gpu-test4.yaml
@@ -32,7 +32,7 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu
@@ -53,7 +53,7 @@ spec:
   - name: ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpu

--- a/demo/gpu-test5.yaml
+++ b/demo/gpu-test5.yaml
@@ -54,7 +54,7 @@ spec:
   - name: ts-ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpus
@@ -62,7 +62,7 @@ spec:
   - name: ts-ctr1
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpus
@@ -70,7 +70,7 @@ spec:
   - name: sp-ctr0
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpus
@@ -78,7 +78,7 @@ spec:
   - name: sp-ctr1
     image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["export; sleep 9999"]
+    args: ["trap 'exit' SIGTERM; export; sleep 9999 & wait"]
     resources:
       claims:
       - name: shared-gpus


### PR DESCRIPTION
This allows all of the demo pods to terminate immediately, without needing to wait for the grace-period of 30s before they receive a SIGKILL.