### PR TITLE
e2e: fail on errors

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -16,6 +16,8 @@
 
 # Very Simple Script for testing the demo
 
+set -e
+
 kind get clusters
 kubectl get nodes
 kubectl wait --for=condition=Ready nodes/dra-example-driver-cluster-worker --timeout=120s


### PR DESCRIPTION
It would be more user friendly to fail on errors when running e2e tests.

Here is an example of how does `make e2e` behaves before and after this fix:

- Before
```
$ make test-e2e
test/e2e/e2e.sh
dra-example-driver-cluster
NAME                                       STATUS   ROLES           AGE    VERSION
dra-example-driver-cluster-control-plane   Ready    control-plane   4d4h   v1.31.0
dra-example-driver-cluster-worker          Ready    <none>          4d4h   v1.31.0
node/dra-example-driver-cluster-worker condition met
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": namespaces "gpu-test1" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": resourceclaimtemplates.resource.k8s.io "single-gpu" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": pods "pod0" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": pods "pod1" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test2.yaml": namespaces "gpu-test2" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test2.yaml": resourceclaimtemplates.resource.k8s.io "multiple-gpus" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test2.yaml": pods "pod0" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test3.yaml": namespaces "gpu-test3" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test3.yaml": resourceclaimtemplates.resource.k8s.io "single-gpu" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test3.yaml": pods "pod0" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test4.yaml": namespaces "gpu-test4" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test4.yaml": resourceclaims.resource.k8s.io "single-gpu" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test4.yaml": pods "pod0" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test4.yaml": pods "pod1" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test5.yaml": namespaces "gpu-test5" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test5.yaml": resourceclaimtemplates.resource.k8s.io "multiple-gpus" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test5.yaml": pods "pod0" already exists
pod/pod0 condition met
pod/pod1 condition met
pod/pod0 condition met
pod/pod0 condition met
pod/pod0 condition met
pod/pod1 condition met
pod/pod0 condition met
test ran successfully
```

- After
```
$ make test-e2e
test/e2e/e2e.sh
dra-example-driver-cluster
NAME                                       STATUS   ROLES           AGE    VERSION
dra-example-driver-cluster-control-plane   Ready    control-plane   4d4h   v1.31.0
dra-example-driver-cluster-worker          Ready    <none>          4d4h   v1.31.0
node/dra-example-driver-cluster-worker condition met
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": namespaces "gpu-test1" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": resourceclaimtemplates.resource.k8s.io "single-gpu" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": pods "pod0" already exists
Error from server (AlreadyExists): error when creating "demo/gpu-test1.yaml": pods "pod1" already exists
make: *** [Makefile:120: test-e2e] Error 1
```