### PR TITLE
add num-devices parameter

### DIFF
--- a/cmd/dra-example-kubeletplugin/discovery.go
+++ b/cmd/dra-example-kubeletplugin/discovery.go
@@ -28,8 +28,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func enumerateAllPossibleDevices() (AllocatableDevices, error) {
-	numGPUs := 8
+func enumerateAllPossibleDevices(numGPUs int) (AllocatableDevices, error) {
 	seed := os.Getenv("NODE_NAME")
 	uuids := generateUUIDs(seed, numGPUs)
 

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -44,8 +44,9 @@ type Flags struct {
 	kubeClientConfig flags.KubeClientConfig
 	loggingConfig    *flags.LoggingConfig
 
-	nodeName string
-	cdiRoot  string
+	nodeName   string
+	cdiRoot    string
+	numDevices int
 }
 
 type Config struct {
@@ -78,6 +79,13 @@ func newApp() *cli.App {
 			Value:       "/etc/cdi",
 			Destination: &flags.cdiRoot,
 			EnvVars:     []string{"CDI_ROOT"},
+		},
+		&cli.IntFlag{
+			Name:        "num-devices",
+			Usage:       "The number of devices to be generated.",
+			Value:       8,
+			Destination: &flags.numDevices,
+			EnvVars:     []string{"NUM_DEVICES"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -63,7 +63,7 @@ type DeviceState struct {
 }
 
 func NewDeviceState(config *Config) (*DeviceState, error) {
-	allocatable, err := enumerateAllPossibleDevices()
+	allocatable, err := enumerateAllPossibleDevices(config.flags.numDevices)
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating all possible devices: %v", err)
 	}

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -53,6 +53,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NUM_DEVICES
+          value: "8"
         volumeMounts:
         - name: plugins-registry
           mountPath: /var/lib/kubelet/plugins_registry


### PR DESCRIPTION
Number of supported devices was set to 8 in the driver code. This was a showstopper for my DRA performance testing where substantial number of pods were created to asses DRA latency, so I made it configurable.