### PR TITLE
Update deployment for Kubernetes 1.31

### DIFF
--- a/deployments/helm/dra-example-driver/templates/clusterrole.yaml
+++ b/deployments/helm/dra-example-driver/templates/clusterrole.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ include "dra-example-driver.fullname" . }}-role
   namespace: {{ include "dra-example-driver.namespace" . }}
 rules:
-- apiGroups:
-  - ""
-  - resource.k8s.io
-  - gpu.resource.example.com
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceslices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/deployments/helm/dra-example-driver/templates/validatingadmissionpolicy.yaml
+++ b/deployments/helm/dra-example-driver/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: resourceslices-policy-{{ include "dra-example-driver.fullname" . }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["resource.k8s.io"]
+      apiVersions: ["v1alpha3"]
+      operations:  ["CREATE", "UPDATE", "DELETE"]
+      resources:   ["resourceslices"]
+  matchConditions:
+  - name: isRestrictedUser
+    expression: >-
+      request.userInfo.username == "system:serviceaccount:{{ include "dra-example-driver.namespace" . }}:{{ include "dra-example-driver.serviceAccountName" . }}"
+  variables:
+  - name: userNodeName
+    expression: >-
+      request.userInfo.extra[?'authentication.kubernetes.io/node-name'][0].orValue('')
+  - name: objectNodeName
+    expression: >-
+      (request.operation == "DELETE" ? oldObject : object).spec.?nodeName.orValue("")
+  validations:
+  - expression: variables.userNodeName != ""
+    message: >-
+      no node association found for user, this user must run in a pod on a node and ServiceAccountTokenPodNodeInfo must be enabled
+  - expression: variables.userNodeName == variables.objectNodeName
+    messageExpression: >-
+      "this user running on node '"+variables.userNodeName+"' may not modify " +
+      (variables.objectNodeName == "" ?"cluster resourceslices" : "resourceslices on node '"+variables.objectNodeName+"'")

--- a/deployments/helm/dra-example-driver/templates/validatingadmissionpolicybinding.yaml
+++ b/deployments/helm/dra-example-driver/templates/validatingadmissionpolicybinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: resourceslices-policy-{{ include "dra-example-driver.fullname" . }}
+spec:
+  policyName: resourceslices-policy-{{ include "dra-example-driver.fullname" . }}
+  validationActions: [Deny]
+  # All ResourceSlices are matched.


### PR DESCRIPTION
- Modified ClusterRole to include only API objects that the driver can access 
- Added ValidatingAdmissionPolicy for resourceslices

Fixes https://github.com/kubernetes-sigs/dra-example-driver/issues/48