### PR TITLE
Properly handle graceful shutdown of the kubelet plugin

### DIFF
--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -70,7 +70,10 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	return driver, nil
 }
 
-func (d *driver) Shutdown(ctx context.Context) error {
+func (d *driver) Shutdown() error {
+	if d == nil {
+		return nil
+	}
 	d.plugin.Stop()
 	return nil
 }

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -141,19 +141,24 @@ func StartPlugin(ctx context.Context, config *Config) error {
 		return fmt.Errorf("path for cdi file generation is not a directory: '%v'", err)
 	}
 
-	driver, err := NewDriver(ctx, config)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	var driver *driver
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		if err := driver.Shutdown(); err != nil {
+			klog.Errorf("Unable to cleanly shutdown driver: %v", err)
+		}
+	}()
+
+	driver, err = NewDriver(ctx, config)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating driver: %w", err)
 	}
 
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-	<-sigc
-
-	err = driver.Shutdown(ctx)
-	if err != nil {
-		klog.FromContext(ctx).Error(err, "Unable to cleanly shutdown driver")
-	}
+	<-sigs
 
 	return nil
 }


### PR DESCRIPTION
Without this change, deletion of the DRA driver will not remove resource slices. There is an open issue in kubernetes (https://github.com/kubernetes/kubernetes/issues/128696) that would ensure that these resources slices get removed even if there is no graceful shutdown, but it's still good to shutdown gracefully regardless.