### PR TITLE
Add validating admission webhook to Helm chart

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,5 @@ jobs:
       run: make PREFIX=artifacts cmds
     - name: List binaries
       run: ls -al artifacts/
-    # no tests yet
-    # - name: Test
-    #   run: go test -v -race ./...
+    - name: Test
+      run: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ kube-system          kube-scheduler-dra-example-driver-cluster-control-plane    
 local-path-storage   local-path-provisioner-7dbf974f64-9jmc7                            1/1     Running   0          1m
 ```
 
+The validating admission webhook is disabled by default. To enable it, install cert-manager and its CRDs, then
+set the `webhook.enabled=true` value when the dra-example-driver chart is installed.
+```bash
+helm install \
+  --repo https://charts.jetstack.io \
+  --version v1.16.3 \
+  --create-namespace \
+  --namespace cert-manager \
+  --wait \
+  --set crds.enabled=true \
+  cert-manager \
+  cert-manager
+```
+More options for installing cert-manager can be found in [their docs](https://cert-manager.io/docs/installation/)
+
 And then install the example resource driver via `helm`.
 ```bash
 helm upgrade -i \
@@ -83,8 +98,9 @@ helm upgrade -i \
 Double check the driver components have come up successfully:
 ```console
 $ kubectl get pod -n dra-example-driver
-NAME                                             READY   STATUS    RESTARTS   AGE
-dra-example-driver-kubeletplugin-qwmbl           1/1     Running   0          1m
+NAME                                                  READY   STATUS    RESTARTS   AGE
+dra-example-driver-kubeletplugin-qwmbl                1/1     Running   0          1m
+dra-example-driver-webhook-7d465fbd5b-n2wxt           1/1     Running   0          1m
 ```
 
 And show the initial state of available GPU devices on the worker node:

--- a/cmd/dra-example-kubeletplugin/cdi.go
+++ b/cmd/dra-example-kubeletplugin/cdi.go
@@ -20,13 +20,15 @@ import (
 	"fmt"
 	"os"
 
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
+
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
 )
 
 const (
-	cdiVendor = "k8s." + DriverName
+	cdiVendor = "k8s." + consts.DriverName
 	cdiClass  = "gpu"
 	cdiKind   = cdiVendor + "/" + cdiClass
 
@@ -60,7 +62,7 @@ func (cdi *CDIHandler) CreateCommonSpecFile() error {
 				ContainerEdits: cdispec.ContainerEdits{
 					Env: []string{
 						fmt.Sprintf("KUBERNETES_NODE_NAME=%s", os.Getenv("NODE_NAME")),
-						fmt.Sprintf("DRA_RESOURCE_DRIVER_NAME=%s", DriverName),
+						fmt.Sprintf("DRA_RESOURCE_DRIVER_NAME=%s", consts.DriverName),
 					},
 				},
 			},

--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/klog/v2"
 
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
 )
 
 var _ drapbv1.DRAPluginServer = &driver{}
@@ -52,7 +54,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		[]any{driver},
 		kubeletplugin.KubeClient(config.coreclient),
 		kubeletplugin.NodeName(config.flags.nodeName),
-		kubeletplugin.DriverName(DriverName),
+		kubeletplugin.DriverName(consts.DriverName),
 		kubeletplugin.RegistrarSocketPath(PluginRegistrationPath),
 		kubeletplugin.PluginSocketPath(DriverPluginSocketPath),
 		kubeletplugin.KubeletPluginSocketPath(DriverPluginSocketPath))

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -28,14 +28,13 @@ import (
 	coreclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
 	"sigs.k8s.io/dra-example-driver/pkg/flags"
 )
 
 const (
-	DriverName = "gpu.example.com"
-
-	PluginRegistrationPath     = "/var/lib/kubelet/plugins_registry/" + DriverName + ".sock"
-	DriverPluginPath           = "/var/lib/kubelet/plugins/" + DriverName
+	PluginRegistrationPath     = "/var/lib/kubelet/plugins_registry/" + consts.DriverName + ".sock"
+	DriverPluginPath           = "/var/lib/kubelet/plugins/" + consts.DriverName
 	DriverPluginSocketPath     = DriverPluginPath + "/plugin.sock"
 	DriverPluginCheckpointFile = "checkpoint.json"
 )

--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 
 	configapi "sigs.k8s.io/dra-example-driver/api/example.com/resource/gpu/v1alpha1"
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
 
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
@@ -180,7 +181,7 @@ func (s *DeviceState) prepareDevices(claim *resourceapi.ResourceClaim) (Prepared
 	// Retrieve the full set of device configs for the driver.
 	configs, err := GetOpaqueDeviceConfigs(
 		configapi.Decoder,
-		DriverName,
+		consts.DriverName,
 		claim.Status.Allocation.Devices.Config,
 	)
 	if err != nil {

--- a/cmd/dra-example-webhook/main.go
+++ b/cmd/dra-example-webhook/main.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+
+	configapi "sigs.k8s.io/dra-example-driver/api/example.com/resource/gpu/v1alpha1"
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
+	"sigs.k8s.io/dra-example-driver/pkg/flags"
+)
+
+var (
+	resourceClaimResource = metav1.GroupVersionResource{
+		Group:    resourceapi.SchemeGroupVersion.Group,
+		Version:  resourceapi.SchemeGroupVersion.Version,
+		Resource: "resourceclaims",
+	}
+	resourceClaimTemplateResource = metav1.GroupVersionResource{
+		Group:    resourceapi.SchemeGroupVersion.Group,
+		Version:  resourceapi.SchemeGroupVersion.Version,
+		Resource: "resourceclaimtemplates",
+	}
+)
+
+type Flags struct {
+	loggingConfig *flags.LoggingConfig
+
+	certFile string
+	keyFile  string
+	port     int
+}
+
+var scheme = runtime.NewScheme()
+var codecs = serializer.NewCodecFactory(scheme)
+
+func init() {
+	utilruntime.Must(admissionv1.AddToScheme(scheme))
+}
+
+func main() {
+	if err := newApp().Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newApp() *cli.App {
+	flags := &Flags{
+		loggingConfig: flags.NewLoggingConfig(),
+	}
+	cliFlags := []cli.Flag{
+		&cli.StringFlag{
+			Name:        "tls-cert-file",
+			Usage:       "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert).",
+			Destination: &flags.certFile,
+			Required:    true,
+		},
+		&cli.StringFlag{
+			Name:        "tls-private-key-file",
+			Usage:       "File containing the default x509 private key matching --tls-cert-file.",
+			Destination: &flags.keyFile,
+			Required:    true,
+		},
+		&cli.IntFlag{
+			Name:        "port",
+			Usage:       "Secure port that the webhook listens on",
+			Value:       443,
+			Destination: &flags.port,
+		},
+	}
+	cliFlags = append(cliFlags, flags.loggingConfig.Flags()...)
+
+	app := &cli.App{
+		Name:            "dra-example-webhook",
+		Usage:           "dra-example-webhook implements a validating admission webhook complementing a DRA driver plugin.",
+		ArgsUsage:       " ",
+		HideHelpCommand: true,
+		Flags:           cliFlags,
+		Before: func(c *cli.Context) error {
+			if c.Args().Len() > 0 {
+				return fmt.Errorf("arguments not supported: %v", c.Args().Slice())
+			}
+			return flags.loggingConfig.Apply()
+		},
+		Action: func(c *cli.Context) error {
+			server := &http.Server{
+				Handler: newMux(),
+				Addr:    fmt.Sprintf(":%d", flags.port),
+			}
+			klog.Info("starting webhook server on", server.Addr)
+			return server.ListenAndServeTLS(flags.certFile, flags.keyFile)
+		},
+	}
+
+	return app
+}
+
+func newMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate-resource-claim-parameters", serveResourceClaim)
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, req *http.Request) {
+		_, err := w.Write([]byte("ok"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	return mux
+}
+
+func serveResourceClaim(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, admitResourceClaimParameters)
+}
+
+// serve handles the http portion of a request prior to handing to an admit
+// function.
+func serve(w http.ResponseWriter, r *http.Request, admit func(admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+	var body []byte
+	if r.Body != nil {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			klog.Error(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		body = data
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		msg := fmt.Sprintf("contentType=%s, expected application/json", contentType)
+		klog.Error(msg)
+		http.Error(w, msg, http.StatusUnsupportedMediaType)
+		return
+	}
+
+	klog.V(2).Infof("handling request: %s", body)
+
+	requestedAdmissionReview, err := readAdmissionReview(body)
+	if err != nil {
+		msg := fmt.Sprintf("failed to read AdmissionReview from request body: %v", err)
+		klog.Error(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+	responseAdmissionReview := &admissionv1.AdmissionReview{}
+	responseAdmissionReview.SetGroupVersionKind(requestedAdmissionReview.GroupVersionKind())
+	responseAdmissionReview.Response = admit(*requestedAdmissionReview)
+	responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
+
+	klog.V(2).Infof("sending response: %v", responseAdmissionReview)
+	respBytes, err := json.Marshal(responseAdmissionReview)
+	if err != nil {
+		klog.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(respBytes); err != nil {
+		klog.Error(err)
+	}
+}
+
+func readAdmissionReview(data []byte) (*admissionv1.AdmissionReview, error) {
+	deserializer := codecs.UniversalDeserializer()
+	obj, gvk, err := deserializer.Decode(data, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("request could not be decoded: %w", err)
+	}
+
+	if *gvk != admissionv1.SchemeGroupVersion.WithKind("AdmissionReview") {
+		return nil, fmt.Errorf("unsupported group version kind: %v", gvk)
+	}
+
+	requestedAdmissionReview, ok := obj.(*admissionv1.AdmissionReview)
+	if !ok {
+		return nil, fmt.Errorf("expected v1.AdmissionReview but got: %T", obj)
+	}
+
+	return requestedAdmissionReview, nil
+}
+
+// admitResourceClaimParameters accepts both ResourceClaims and ResourceClaimTemplates and validates their
+// opaque device configuration parameters for this driver.
+func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	klog.V(2).Info("admitting resource claim parameters")
+
+	var deviceConfigs []resourceapi.DeviceClaimConfiguration
+	var specPath string
+
+	raw := ar.Request.Object.Raw
+	deserializer := codecs.UniversalDeserializer()
+
+	switch ar.Request.Resource {
+	case resourceClaimResource:
+		claim := resourceapi.ResourceClaim{}
+		if _, _, err := deserializer.Decode(raw, nil, &claim); err != nil {
+			klog.Error(err)
+			return &admissionv1.AdmissionResponse{
+				Result: &metav1.Status{
+					Message: err.Error(),
+					Reason:  metav1.StatusReasonBadRequest,
+				},
+			}
+		}
+		deviceConfigs = claim.Spec.Devices.Config
+		specPath = "spec"
+	case resourceClaimTemplateResource:
+		claimTemplate := resourceapi.ResourceClaimTemplate{}
+		if _, _, err := deserializer.Decode(raw, nil, &claimTemplate); err != nil {
+			klog.Error(err)
+			return &admissionv1.AdmissionResponse{
+				Result: &metav1.Status{
+					Message: err.Error(),
+					Reason:  metav1.StatusReasonBadRequest,
+				},
+			}
+		}
+		deviceConfigs = claimTemplate.Spec.Spec.Devices.Config
+		specPath = "spec.spec"
+	default:
+		msg := fmt.Sprintf("expected resource to be %s or %s, got %s", resourceClaimResource, resourceClaimTemplateResource, ar.Request.Resource)
+		klog.Error(msg)
+		return &admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: msg,
+				Reason:  metav1.StatusReasonBadRequest,
+			},
+		}
+	}
+
+	var errs []error
+	for configIndex, config := range deviceConfigs {
+		if config.Opaque == nil || config.Opaque.Driver != consts.DriverName {
+			continue
+		}
+
+		fieldPath := fmt.Sprintf("%s.devices.config[%d].opaque.parameters", specPath, configIndex)
+		decodedConfig, err := runtime.Decode(configapi.Decoder, config.DeviceConfiguration.Opaque.Parameters.Raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error decoding object at %s: %w", fieldPath, err))
+			continue
+		}
+		gpuConfig, ok := decodedConfig.(*configapi.GpuConfig)
+		if !ok {
+			errs = append(errs, fmt.Errorf("expected v1alpha1.GpuConfig at %s but got: %T", fieldPath, decodedConfig))
+			continue
+		}
+		err = gpuConfig.Validate()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("object at %s is invalid: %w", fieldPath, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		var errMsgs []string
+		for _, err := range errs {
+			errMsgs = append(errMsgs, err.Error())
+		}
+		msg := fmt.Sprintf("%d configs failed to validate: %s", len(errs), strings.Join(errMsgs, "; "))
+		klog.Error(msg)
+		return &admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: msg,
+				Reason:  metav1.StatusReason(metav1.StatusReasonInvalid),
+			},
+		}
+	}
+
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+}

--- a/cmd/dra-example-webhook/main_test.go
+++ b/cmd/dra-example-webhook/main_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configapi "sigs.k8s.io/dra-example-driver/api/example.com/resource/gpu/v1alpha1"
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
+)
+
+func TestReadyEndpoint(t *testing.T) {
+	s := httptest.NewServer(newMux())
+	t.Cleanup(s.Close)
+
+	res, err := http.Get(s.URL + "/readyz")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestResourceClaimValidatingWebhook(t *testing.T) {
+	tests := map[string]struct {
+		admissionReview      *admissionv1.AdmissionReview
+		requestContentType   string
+		expectedResponseCode int
+		expectedAllowed      bool
+		expectedMessage      string
+	}{
+		"bad contentType": {
+			requestContentType:   "invalid type",
+			expectedResponseCode: http.StatusUnsupportedMediaType,
+		},
+		"invalid AdmissionReview": {
+			admissionReview:      &admissionv1.AdmissionReview{},
+			expectedResponseCode: http.StatusBadRequest,
+		},
+		"valid GpuConfig in ResourceClaim": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithGpuConfigs(
+					&configapi.GpuConfig{
+						Sharing: &configapi.GpuSharing{
+							Strategy: configapi.TimeSlicingStrategy,
+							TimeSlicingConfig: &configapi.TimeSlicingConfig{
+								Interval: configapi.DefaultTimeSlice,
+							},
+						},
+					},
+				),
+				resourceClaimResource,
+			),
+			expectedAllowed: true,
+		},
+		"invalid GpuConfigs in ResourceClaim": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithGpuConfigs(
+					&configapi.GpuConfig{
+						Sharing: &configapi.GpuSharing{
+							Strategy: configapi.TimeSlicingStrategy,
+							TimeSlicingConfig: &configapi.TimeSlicingConfig{
+								Interval: "InvalidInterval",
+							},
+						},
+					},
+					&configapi.GpuConfig{
+						Sharing: &configapi.GpuSharing{
+							Strategy: configapi.SpacePartitioningStrategy,
+							SpacePartitioningConfig: &configapi.SpacePartitioningConfig{
+								PartitionCount: -1,
+							},
+						},
+					},
+				),
+				resourceClaimResource,
+			),
+			expectedAllowed: false,
+			expectedMessage: "2 configs failed to validate: object at spec.devices.config[0].opaque.parameters is invalid: unknown time-slice interval: InvalidInterval; object at spec.devices.config[1].opaque.parameters is invalid: invalid partition count: -1",
+		},
+		"valid GpuConfig in ResourceClaimTemplate": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimTemplateWithGpuConfigs(
+					&configapi.GpuConfig{
+						Sharing: &configapi.GpuSharing{
+							Strategy: configapi.TimeSlicingStrategy,
+							TimeSlicingConfig: &configapi.TimeSlicingConfig{
+								Interval: configapi.DefaultTimeSlice,
+							},
+						},
+					},
+				),
+				resourceClaimTemplateResource,
+			),
+			expectedAllowed: true,
+		},
+		"invalid GpuConfigs in ResourceClaimTemplate": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimTemplateWithGpuConfigs(
+					&configapi.GpuConfig{
+						Sharing: &configapi.GpuSharing{
+							Strategy: configapi.TimeSlicingStrategy,
+							TimeSlicingConfig: &configapi.TimeSlicingConfig{
+								Interval: "InvalidInterval",
+							},
+						},
+					},
+					&configapi.GpuConfig{
+						Sharing: &configapi.GpuSharing{
+							Strategy: configapi.SpacePartitioningStrategy,
+							SpacePartitioningConfig: &configapi.SpacePartitioningConfig{
+								PartitionCount: -1,
+							},
+						},
+					},
+				),
+				resourceClaimTemplateResource,
+			),
+			expectedAllowed: false,
+			expectedMessage: "2 configs failed to validate: object at spec.spec.devices.config[0].opaque.parameters is invalid: unknown time-slice interval: InvalidInterval; object at spec.spec.devices.config[1].opaque.parameters is invalid: invalid partition count: -1",
+		},
+	}
+
+	s := httptest.NewServer(newMux())
+	t.Cleanup(s.Close)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			requestBody, err := json.Marshal(test.admissionReview)
+			require.NoError(t, err)
+
+			contentType := test.requestContentType
+			if contentType == "" {
+				contentType = "application/json"
+			}
+
+			res, err := http.Post(s.URL+"/validate-resource-claim-parameters", contentType, bytes.NewReader(requestBody))
+			require.NoError(t, err)
+			expectedResponseCode := test.expectedResponseCode
+			if expectedResponseCode == 0 {
+				expectedResponseCode = http.StatusOK
+			}
+			assert.Equal(t, expectedResponseCode, res.StatusCode)
+			if res.StatusCode != http.StatusOK {
+				// We don't have an AdmissionReview to validate
+				return
+			}
+
+			responseBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			res.Body.Close()
+
+			responseAdmissionReview, err := readAdmissionReview(responseBody)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedAllowed, responseAdmissionReview.Response.Allowed)
+			if !test.expectedAllowed {
+				assert.Equal(t, test.expectedMessage, string(responseAdmissionReview.Response.Result.Message))
+			}
+		})
+	}
+}
+
+func admissionReviewWithObject(obj runtime.Object, resource metav1.GroupVersionResource) *admissionv1.AdmissionReview {
+	requestedAdmissionReview := &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Resource: resource,
+			Object: runtime.RawExtension{
+				Object: obj,
+			},
+		},
+	}
+	requestedAdmissionReview.SetGroupVersionKind(admissionv1.SchemeGroupVersion.WithKind("AdmissionReview"))
+	return requestedAdmissionReview
+}
+
+func resourceClaimWithGpuConfigs(gpuConfigs ...*configapi.GpuConfig) *resourceapi.ResourceClaim {
+	resourceClaim := &resourceapi.ResourceClaim{
+		Spec: resourceClaimSpecWithGpuConfigs(gpuConfigs...),
+	}
+	resourceClaim.SetGroupVersionKind(resourceapi.SchemeGroupVersion.WithKind("ResourceClaim"))
+	return resourceClaim
+}
+
+func resourceClaimTemplateWithGpuConfigs(gpuConfigs ...*configapi.GpuConfig) *resourceapi.ResourceClaimTemplate {
+	resourceClaimTemplate := &resourceapi.ResourceClaimTemplate{
+		Spec: resourceapi.ResourceClaimTemplateSpec{
+			Spec: resourceClaimSpecWithGpuConfigs(gpuConfigs...),
+		},
+	}
+	resourceClaimTemplate.SetGroupVersionKind(resourceapi.SchemeGroupVersion.WithKind("ResourceClaimTemplate"))
+	return resourceClaimTemplate
+}
+
+func resourceClaimSpecWithGpuConfigs(gpuConfigs ...*configapi.GpuConfig) resourceapi.ResourceClaimSpec {
+	resourceClaimSpec := resourceapi.ResourceClaimSpec{}
+	for _, gpuConfig := range gpuConfigs {
+		gpuConfig.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   configapi.GroupName,
+			Version: configapi.Version,
+			Kind:    "GpuConfig",
+		})
+		deviceConfig := resourceapi.DeviceClaimConfiguration{
+			DeviceConfiguration: resourceapi.DeviceConfiguration{
+				Opaque: &resourceapi.OpaqueDeviceConfiguration{
+					Driver: consts.DriverName,
+					Parameters: runtime.RawExtension{
+						Object: gpuConfig,
+					},
+				},
+			},
+		}
+		resourceClaimSpec.Devices.Config = append(resourceClaimSpec.Devices.Config, deviceConfig)
+	}
+	return resourceClaimSpec
+}

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -35,3 +35,4 @@ LABEL summary="Example DRA resource driver for Kubernetes"
 LABEL description="See summary"
 
 COPY --from=build /artifacts/dra-example-kubeletplugin /usr/bin/dra-example-kubeletplugin
+COPY --from=build /artifacts/dra-example-webhook       /usr/bin/dra-example-webhook

--- a/deployments/helm/dra-example-driver/templates/_helpers.tpl
+++ b/deployments/helm/dra-example-driver/templates/_helpers.tpl
@@ -95,3 +95,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use for the webhook
+*/}}
+{{- define "dra-example-driver.webhookServiceAccountName" -}}
+{{- $name := printf "%s-webhook-service-account" (include "dra-example-driver.fullname" .) }}
+{{- if .Values.webhook.serviceAccount.create }}
+{{- default $name .Values.webhook.serviceAccount.name }}
+{{- else }}
+{{- default "default-webhook" .Values.webhook.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -6,10 +6,12 @@ metadata:
   namespace: {{ include "dra-example-driver.namespace" . }}
   labels:
     {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubeletplugin
 spec:
   selector:
     matchLabels:
       {{- include "dra-example-driver.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kubeletplugin
   {{- with .Values.kubeletPlugin.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -22,6 +24,7 @@ spec:
       {{- end }}
       labels:
         {{- include "dra-example-driver.templateLabels" . | nindent 8 }}
+        app.kubernetes.io/component: kubeletplugin
     spec:
       {{- if .Values.kubeletPlugin.priorityClassName }}
       priorityClassName: {{ .Values.kubeletPlugin.priorityClassName }}

--- a/deployments/helm/dra-example-driver/templates/validatingwebhookconfiguration.yaml
+++ b/deployments/helm/dra-example-driver/templates/validatingwebhookconfiguration.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-webhook-config
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ include "dra-example-driver.namespace" . }}/{{ include "dra-example-driver.fullname" . }}-webhook-cert"
+webhooks:
+- name: "dra.example.com"
+  rules:
+  - apiGroups:   ["resource.k8s.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["resourceclaims", "resourceclaimtemplates"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: {{ include "dra-example-driver.namespace" . }}
+      name: {{ include "dra-example-driver.fullname" . }}-webhook
+      port: {{ .Values.webhook.servicePort }}
+      path: /validate-resource-claim-parameters
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/webhook-cert-issuer.yaml
+++ b/deployments/helm/dra-example-driver/templates/webhook-cert-issuer.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-webhook-issuer
+  namespace: {{ include "dra-example-driver.namespace" . }}
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+spec:
+  selfSigned: {}
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/webhook-cert.yaml
+++ b/deployments/helm/dra-example-driver/templates/webhook-cert.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-webhook-cert
+  namespace: {{ include "dra-example-driver.namespace" . }}
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+spec:
+  dnsNames:
+    {{- $svcName := printf "%s-webhook" (include "dra-example-driver.fullname" .) }}
+    {{- $svcNamespace := (include "dra-example-driver.namespace" .) }}
+    - {{ $svcName }}.{{ $svcNamespace }}.svc
+  issuerRef:
+    kind: Issuer
+    name: {{ include "dra-example-driver.fullname" . }}-webhook-issuer
+  secretName: {{ include "dra-example-driver.fullname" . }}-webhook-cert
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/webhook-deployment.yaml
+++ b/deployments/helm/dra-example-driver/templates/webhook-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-webhook
+  namespace: {{ include "dra-example-driver.namespace" . }}
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+spec:
+  selector:
+    matchLabels:
+      {{- include "dra-example-driver.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: webhook
+  template:
+    metadata:
+      {{- with .Values.webhook.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dra-example-driver.templateLabels" . | nindent 8 }}
+        app.kubernetes.io/component: webhook
+    spec:
+      {{- if .Values.webhook.priorityClassName }}
+      priorityClassName: {{ .Values.webhook.priorityClassName }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dra-example-driver.webhookServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.webhook.podSecurityContext | nindent 8 }}
+      containers:
+      - name: webhook
+        securityContext:
+          {{- toYaml .Values.webhook.containers.webhook.securityContext | nindent 10 }}
+        image: {{ include "dra-example-driver.fullimage" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["dra-example-webhook"]
+        args:
+          - --tls-cert-file=/cert/tls.crt
+          - --tls-private-key-file=/cert/tls.key
+          - --port={{ .Values.webhook.containerPort }}
+        ports:
+          - name: webhook
+            containerPort: {{ .Values.webhook.containerPort }}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: webhook
+            scheme: HTTPS
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: webhook
+            scheme: HTTPS
+        volumeMounts:
+        - name: cert
+          mountPath: /cert
+          readOnly: true
+        resources:
+          {{- toYaml .Values.webhook.containers.webhook.resources | nindent 10 }}
+      volumes:
+      - name: cert
+        secret:
+          secretName: {{ include "dra-example-driver.fullname" . }}-webhook-cert
+      {{- with .Values.webhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/webhook-serviceaccount.yaml
+++ b/deployments/helm/dra-example-driver/templates/webhook-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.webhook.enabled }}
+{{- if .Values.webhook.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dra-example-driver.webhookServiceAccountName" . }}
+  namespace: {{ include "dra-example-driver.namespace" . }}
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+  {{- with .Values.webhook.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/webhook-svc.yaml
+++ b/deployments/helm/dra-example-driver/templates/webhook-svc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-webhook
+  namespace: {{ include "dra-example-driver.namespace" . }}
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+spec:
+  selector:
+    {{- include "dra-example-driver.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+  ports:
+  - name: webhook
+    protocol: TCP
+    port: {{ .Values.webhook.servicePort }}
+    targetPort: webhook
+{{- end }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -61,3 +61,29 @@ kubeletPlugin:
       securityContext:
         privileged: true
       resources: {}
+
+webhook:
+  enabled: false
+  servicePort: 443
+  containerPort: 443
+  priorityClassName: "system-cluster-critical"
+  strategy:
+    type: RollingUpdate
+  podAnnotations: {}
+  podSecurityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  containers:
+    webhook:
+      securityContext:
+        privileged: false
+      resources: {}
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.1
 require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.25.3
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
@@ -48,6 +49,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package consts
+
+const DriverName = "gpu.example.com"

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -19,8 +19,20 @@ set -e
 
 bash demo/build-driver.sh
 bash demo/create-cluster.sh
+
+helm upgrade -i \
+  --repo https://charts.jetstack.io \
+  --version v1.16.3 \
+  --create-namespace \
+  --namespace cert-manager \
+  --wait \
+  --set crds.enabled=true \
+  cert-manager \
+  cert-manager
+
 helm upgrade -i \
   --create-namespace \
   --namespace dra-example-driver \
+  --set webhook.enabled=true \
   dra-example-driver \
   deployments/helm/dra-example-driver


### PR DESCRIPTION
This change adds a validating admission webhook that validates the
driver-specific opaque parameters that can be specified in
ResourceClaims and ResourceClaimTemplates.

Fixes #49