### PR TITLE
Add config for staging repo image build

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,0 +1,15 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: E2_HIGHCPU_32
+steps:
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
+  entrypoint: bash
+  env:
+  - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
+  - DRIVER_IMAGE_TAG=$COMMIT_SHA
+  args:
+    - -ec
+    - |
+      demo/scripts/build-driver-image.sh
+      demo/scripts/push-driver-image.sh

--- a/demo/scripts/push-driver-image.sh
+++ b/demo/scripts/push-driver-image.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A reference to the current directory where this script is located
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/common.sh"
+
+# Set build variables
+export REGISTRY="${DRIVER_IMAGE_REGISTRY}"
+export IMAGE="${DRIVER_IMAGE_NAME}"
+export VERSION="${DRIVER_IMAGE_TAG}"
+export CONTAINER_TOOL="${CONTAINER_TOOL}"
+
+make -f deployments/container/Makefile push

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -38,3 +38,6 @@ $(DISTRIBUTIONS):
 		--build-arg VERSION="$(VERSION)" \
 		-f $(DOCKERFILE) \
 		$(CURDIR)
+
+push:
+	$(CONTAINER_TOOL) push $(IMAGE)


### PR DESCRIPTION
This PR adds a cloudbuild.yaml which serves as input to https://github.com/kubernetes/test-infra/pull/34376 which defines how images should be built and pushed to the new staging repo added by https://github.com/kubernetes/k8s.io/pull/7703.

Part of #64