### PR TITLE
use _GIT_TAG for staging repo image tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
   entrypoint: bash
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
-  - DRIVER_IMAGE_TAG=$COMMIT_SHA
+  - DRIVER_IMAGE_TAG=$_GIT_TAG # _GIT_TAG is injected by Prow
   args:
     - -ec
     - |


### PR DESCRIPTION
`$COMMIT_SHA` seems to be empty as the resulting image was tagged with the default `v0.1.0` tag: https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/dra-example-driver/dra-example-driver/sha256:0e8f5df34c196e5900c4d29667ce5b21ba482ef9aecc5dd19cea14fa6dde2d0c;tab=attachments?project=k8s-staging-images

`$_GIT_TAG` is a variable injected by the Prow job that seems to be what's generally used for image tags: https://github.com/kubernetes/test-infra/blob/3e2b92318e41a47e569a90f0c71db3bcb81b9902/images/builder/README.md