### PR TITLE
Add Helm chart OCI push to cloudbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 ./dra-example-kubeletplugin
 
 driver_image.tar
+*.tgz

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ $(DOCKER_TARGETS): docker-%: .build-image
 			make $(*)
 
 # Start an interactive shell using the development image.
-PHONY: .shell
+.PHONY: .shell
 .shell:
 	$(CONTAINER_TOOL) run \
 		--rm \
@@ -165,3 +165,14 @@ PHONY: .shell
 		$(CONTAINER_TOOL_OPTS) \
 		-w $(PWD) \
 		$(BUILDIMAGE)
+
+.PHONY: push-release-artifacts
+push-release-artifacts:
+	if echo -n "${GIT_TAG}" | grep -q "^chart/"; then \
+		export CHART_VERSION="$${GIT_TAG##chart/}"; \
+		demo/scripts/push-driver-chart.sh; \
+	else \
+		export DRIVER_IMAGE_TAG="${GIT_TAG}"; \
+		demo/scripts/build-driver-image.sh; \
+		demo/scripts/push-driver-image.sh; \
+	fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,12 +4,10 @@ options:
   machineType: E2_HIGHCPU_32
 steps:
 - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
-  entrypoint: bash
+  entrypoint: make
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
-  - DRIVER_IMAGE_TAG=$_GIT_TAG # _GIT_TAG is injected by Prow
+  - DRIVER_CHART_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/charts
+  - GIT_TAG=$_GIT_TAG # _GIT_TAG is injected by the image builder running in Prow
   args:
-    - -ec
-    - |
-      demo/scripts/build-driver-image.sh
-      demo/scripts/push-driver-image.sh
+    - push-release-artifacts

--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -26,9 +26,9 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 : ${DRIVER_NAME:=dra-example-driver}
 
 # The registry, image and tag for the example driver
-: ${DRIVER_IMAGE_REGISTRY:="registry.example.com"}
+: ${DRIVER_IMAGE_REGISTRY:="registry.k8s.io"}
 : ${DRIVER_IMAGE_NAME:="${DRIVER_NAME}"}
-: ${DRIVER_IMAGE_TAG:="v0.1.0"}
+: ${DRIVER_IMAGE_TAG:="$(helm show chart $(git rev-parse --show-toplevel)/deployments/helm/${DRIVER_NAME} | sed -n 's/^appVersion: //p')"}
 : ${DRIVER_IMAGE_PLATFORM:="ubuntu22.04"}
 
 # The kubernetes repo to build the kind cluster from

--- a/demo/scripts/push-driver-chart.sh
+++ b/demo/scripts/push-driver-chart.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A reference to the current directory where this script is located
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/common.sh"
+
+# Set build variables
+export REGISTRY="${DRIVER_CHART_REGISTRY}"
+export CHART_NAME="${DRIVER_NAME}"
+
+helm package --version "${CHART_VERSION}" deployments/helm/dra-example-driver
+helm push "${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${REGISTRY}"

--- a/deployments/helm/dra-example-driver/Chart.yaml
+++ b/deployments/helm/dra-example-driver/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "v0.1.0"

--- a/deployments/helm/dra-example-driver/templates/_helpers.tpl
+++ b/deployments/helm/dra-example-driver/templates/_helpers.tpl
@@ -80,8 +80,7 @@ Selector labels
 Full image name with tag
 */}}
 {{- define "dra-example-driver.fullimage" -}}
-{{- $tag := printf "v%s" .Chart.AppVersion }}
-{{- .Values.image.repository -}}:{{- .Values.image.tag | default $tag -}}
+{{- .Values.image.repository -}}:{{- .Values.image.tag | default .Chart.AppVersion -}}
 {{- end }}
 
 {{/*

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -11,7 +11,7 @@ allowDefaultNamespace: false
 
 imagePullSecrets: []
 image:
-  repository: registry.example.com/dra-example-driver
+  repository: registry.k8s.io/dra-example-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
These changes enable the Helm chart to be pushed as an OCI artifact to the staging repository. This is the rough release process I had in mind, hoping to gather feedback and iterate in this PR:

1. We open a PR here to update the Chart.yaml's `appVersion` to match the new tag that will be created.
2. A maintainer pushes a semver Git tag (e.g. `v0.1.0`) which matches the chart's new `appVersion`.
    - Prow kicks off an image build and pushes to the staging repo, resulting in the image `us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver/dra-example-driver:v0.1.0`.
3. For the same commit, a maintainer pushes a `chart/<semver>` Git tag, (e.g. `chart/0.12.0`, [no leading "v"](https://github.com/kubernetes-sigs/kueue/issues/4445)).
    - Prow similarly pushes the chart to `us-central1-docker.pkg.dev/k8s-staging-images/charts/dra-example-driver:0.12.0`
4. Anyone can then open a PR to k8s.io that will promote the image and chart to registry.k8s.io (e.g. https://github.com/kubernetes/k8s.io/pull/7830).
5. A maintainer publishes a GitHub release.