### PR TITLE
Cut chart release 0.1.0

### DIFF
--- a/deployments/helm/dra-example-driver/Chart.yaml
+++ b/deployments/helm/dra-example-driver/Chart.yaml
@@ -15,6 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
+# This should not be manually updated. It will be automatically set based on a
+# Git tag when a release is published.
 version: 0.0.0-dev
 
 # This is the version number of the application being deployed. This version number should be
@@ -22,3 +24,5 @@ version: 0.0.0-dev
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.1.0"
+
+kubeVersion: "1.32.x"


### PR DESCRIPTION
This PR fulfills step 1 of the [proposed release process](https://github.com/kubernetes-sigs/dra-example-driver/pull/81#issue-2888334130). Normally, this PR would update the Chart.yaml's `appVersion`, but `v0.1.0` seems as good a place as any to start. If we'd feel better to create some pre-release tag like `v0.1.0-rc.1` before cutting the final `v0.1.0`, I'm happy to update that here.

After this PR merges, I'll need help from someone with write access to this repo to push two tags: one to trigger pushing the container image to the staging repo, and one to trigger pushing the Helm chart to the staging repo. Those tags will be `v0.1.0` (literally the `appVersion`) and `chart/0.1.0` (no leading "v"), or both with a pre-release tag like `-rc.1` if we go that route. I think someone from either @kubernetes-sigs/dra-example-driver-admins or @kubernetes-sigs/dra-example-driver-maintainers should be able to do that.