### PR TITLE
Fix image and chart tags used for staging repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ MKDIR    ?= mkdir
 TR       ?= tr
 DIST_DIR ?= $(CURDIR)/dist
 
+export IMAGE_GIT_TAG ?= $(shell git describe --tags --always --dirty --match 'v*')
+export CHART_GIT_TAG ?= $(shell git describe --tags --always --dirty --match 'chart/*')
+
 include $(CURDIR)/common.mk
 
 BUILDIMAGE_TAG ?= golang$(GOLANG_VERSION)
@@ -168,11 +171,8 @@ $(DOCKER_TARGETS): docker-%: .build-image
 
 .PHONY: push-release-artifacts
 push-release-artifacts:
-	if echo -n "${GIT_TAG}" | grep -q "^chart/"; then \
-		export CHART_VERSION="$${GIT_TAG##chart/}"; \
-		demo/scripts/push-driver-chart.sh; \
-	else \
-		export DRIVER_IMAGE_TAG="${GIT_TAG}"; \
-		demo/scripts/build-driver-image.sh; \
-		demo/scripts/push-driver-image.sh; \
-	fi
+	CHART_VERSION="$${CHART_GIT_TAG##chart/}" \
+		demo/scripts/push-driver-chart.sh
+	export DRIVER_IMAGE_TAG="${IMAGE_GIT_TAG}"; \
+	demo/scripts/build-driver-image.sh && \
+	demo/scripts/push-driver-image.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,6 +8,5 @@ steps:
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
   - DRIVER_CHART_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/charts
-  - GIT_TAG=$_GIT_TAG # _GIT_TAG is injected by the image builder running in Prow
   args:
     - push-release-artifacts


### PR DESCRIPTION
This PR replaces our use of the automatically-injected `_GIT_TAG` substitution in cloudbuild.yaml with the plain Git tag, not prefixed by a date. When the tag is prefixed by the date, the old logic in the Makefile to detect a `chart/` prefix failed to trigger, so the chart did not get pushed to the staging repo.