### PR TITLE
invoke Helm with `go run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CONTAINER_TOOL ?= docker
 MKDIR    ?= mkdir
 TR       ?= tr
 DIST_DIR ?= $(CURDIR)/dist
+HELM     ?= "go run helm.sh/helm/v3/cmd/helm@latest"
 
 export IMAGE_GIT_TAG ?= $(shell git describe --tags --always --dirty --match 'v*')
 export CHART_GIT_TAG ?= $(shell git describe --tags --always --dirty --match 'chart/*')
@@ -172,6 +173,7 @@ $(DOCKER_TARGETS): docker-%: .build-image
 .PHONY: push-release-artifacts
 push-release-artifacts:
 	CHART_VERSION="$${CHART_GIT_TAG##chart/}" \
+		HELM=$(HELM) \
 		demo/scripts/push-driver-chart.sh
 	export DRIVER_IMAGE_TAG="${IMAGE_GIT_TAG}"; \
 	demo/scripts/build-driver-image.sh && \

--- a/demo/scripts/push-driver-chart.sh
+++ b/demo/scripts/push-driver-chart.sh
@@ -26,5 +26,5 @@ source "${CURRENT_DIR}/common.sh"
 export REGISTRY="${DRIVER_CHART_REGISTRY}"
 export CHART_NAME="${DRIVER_NAME}"
 
-helm package --version "${CHART_VERSION}" deployments/helm/dra-example-driver
-helm push "${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${REGISTRY}"
+${HELM} package --version "${CHART_VERSION}" deployments/helm/dra-example-driver
+${HELM} push "${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${REGISTRY}"


### PR DESCRIPTION
The docker image used to push the Helm chart doesn't include `helm`, so we have to ensure that's available ourselves. This PR adds that by invoking Helm with `go run`.