### PR TITLE
Fix image repo used in chart

### DIFF
--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -26,7 +26,7 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 : ${DRIVER_NAME:=dra-example-driver}
 
 # The registry, image and tag for the example driver
-: ${DRIVER_IMAGE_REGISTRY:="registry.k8s.io"}
+: ${DRIVER_IMAGE_REGISTRY:="registry.k8s.io/dra-example-driver"}
 : ${DRIVER_IMAGE_NAME:="${DRIVER_NAME}"}
 : ${DRIVER_IMAGE_TAG:="$(helm show chart $(git rev-parse --show-toplevel)/deployments/helm/${DRIVER_NAME} | sed -n 's/^appVersion: //p')"}
 : ${DRIVER_IMAGE_PLATFORM:="ubuntu22.04"}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -11,7 +11,7 @@ allowDefaultNamespace: false
 
 imagePullSecrets: []
 image:
-  repository: registry.k8s.io/dra-example-driver
+  repository: registry.k8s.io/dra-example-driver/dra-example-driver
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
This PR adds a missing `/dra-example-driver` to make the default `image.repository` value for the chart `registry.k8s.io/dra-example-driver/dra-example-driver` which will be the correct name of the image that ultimately gets promoted.

(I think this is the last fix before we can promote the image and chart to prod, but I shouldn't make any promises.)