### PR TITLE
Push chart to subproject directory in staging repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,6 @@ steps:
   entrypoint: make
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
-  - DRIVER_CHART_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/charts
+  - DRIVER_CHART_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver/charts
   args:
     - push-release-artifacts


### PR DESCRIPTION
This PR updates the location in the staging repo where the Helm chart is pushed to underneath the `/dra-example-driver` path per the [discussion on Slack](https://kubernetes.slack.com/archives/CCK68P2Q2/p1742310780701549).

I've manually copied the existing [0.1.3 tag](https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/charts/dra-example-driver/sha256:ab5cd9fd898b2ff79bea030520170a7feb579ff463dce9758775f7cce7d7231f?invt=AbsZNA&project=k8s-staging-images&inv=1) in the higher-level `/charts` to the [new location](https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/dra-example-driver/charts%2Fdra-example-driver/sha256:ab5cd9fd898b2ff79bea030520170a7feb579ff463dce9758775f7cce7d7231f?invt=AbsZMw&project=k8s-staging-images&inv=1) (preserving the SHA digest), so no need to push a new tag after this merges.