### PR TITLE
Make kubelet plugin dirs configurable

### DIFF
--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -54,6 +54,8 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.KubeClient(config.coreclient),
 		kubeletplugin.NodeName(config.flags.nodeName),
 		kubeletplugin.DriverName(consts.DriverName),
+		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
+		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -79,7 +79,7 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("unable to create CDI spec file for common edits: %v", err)
 	}
 
-	checkpointManager, err := checkpointmanager.NewCheckpointManager(DriverPluginPath)
+	checkpointManager, err := checkpointmanager.NewCheckpointManager(config.DriverPluginPath())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create checkpoint manager: %v", err)
 	}

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -48,6 +48,10 @@ spec:
         env:
         - name: CDI_ROOT
           value: /var/run/cdi
+        - name: KUBELET_REGISTRAR_DIRECTORY_PATH
+          value: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
+        - name: KUBELET_PLUGINS_DIRECTORY_PATH
+          value: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -61,18 +65,18 @@ spec:
           value: "8"
         volumeMounts:
         - name: plugins-registry
-          mountPath: /var/lib/kubelet/plugins_registry
+          mountPath: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
         - name: plugins
-          mountPath: /var/lib/kubelet/plugins
+          mountPath: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
         - name: cdi
           mountPath: /var/run/cdi
       volumes:
       - name: plugins-registry
         hostPath:
-          path: /var/lib/kubelet/plugins_registry
+          path: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
       - name: plugins
         hostPath:
-          path: /var/lib/kubelet/plugins
+          path: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
       - name: cdi
         hostPath:
           path: /var/run/cdi

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -53,6 +53,8 @@ kubeletPlugin:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  kubeletRegistrarDirectoryPath: /var/lib/kubelet/plugins_registry
+  kubeletPluginsDirectoryPath: /var/lib/kubelet/plugins
   containers:
     init:
       securityContext: {}


### PR DESCRIPTION
Follow-up from https://github.com/kubernetes-sigs/dra-example-driver/pull/95#discussion_r2073367665

This PR adds two new values to the Helm chart to configure paths needed to initialize kubelet plugins in case a cluster uses non-default paths for kubelet data.

I tested locally with these changes to use a non-default value for each:
```diff
diff --git a/demo/scripts/kind-cluster-config.yaml b/demo/scripts/kind-cluster-config.yaml
index 997c306..04cfd13 100644
--- a/demo/scripts/kind-cluster-config.yaml
+++ b/demo/scripts/kind-cluster-config.yaml
@@ -34,3 +34,4 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         v: "1"
+        root-dir: /var/lib/kubelet2
diff --git a/test/e2e/setup-e2e.sh b/test/e2e/setup-e2e.sh
index c45fddf..bcc5b1a 100755
--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -34,5 +34,7 @@ helm upgrade -i \
   --create-namespace \
   --namespace dra-example-driver \
   --set webhook.enabled=true \
+  --set kubeletPlugin.kubeletRegistrarDirectoryPath=/var/lib/kubelet2/plugins_registry \
+  --set kubeletPlugin.kubeletPluginsDirectoryPath=/var/lib/kubelet2/plugins \
   dra-example-driver \
   deployments/helm/dra-example-driver
```