### PR TITLE
Bump cloudbuild image to Go 1.24

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
   entrypoint: make
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver


### PR DESCRIPTION
Fixes #102 

Since #95, the post-dra-example-driver-image job has been failing because the base image used for cloudbuild hadn't been updated to one with Go 1.24. This PR updates that image.

Before:
```console
% docker run --rm --entrypoint go gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d version
go version go1.23.4 linux/amd64
```

After:
```console
% docker run --rm --entrypoint go gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079 version
go version go1.24.3 linux/amd64
```