### PR TITLE
Add livenessProbe to kubelet plugin

### DIFF
--- a/cmd/dra-example-kubeletplugin/health.go
+++ b/cmd/dra-example-kubeletplugin/health.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"path"
+	"strconv"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+	drapb "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+
+	"sigs.k8s.io/dra-example-driver/pkg/consts"
+)
+
+type healthcheck struct {
+	grpc_health_v1.UnimplementedHealthServer
+
+	server *grpc.Server
+	wg     sync.WaitGroup
+
+	regClient registerapi.RegistrationClient
+	draClient drapb.DRAPluginClient
+}
+
+func startHealthcheck(ctx context.Context, config *Config) (*healthcheck, error) {
+	log := klog.FromContext(ctx)
+
+	port := config.flags.healthcheckPort
+	if port < 0 {
+		return nil, nil
+	}
+
+	addr := net.JoinHostPort("", strconv.Itoa(port))
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen for healthcheck service at %s: %w", addr, err)
+	}
+
+	regSockPath := (&url.URL{
+		Scheme: "unix",
+		// TODO: this needs to adapt when seamless upgrades
+		// are enabled and the filename includes a uid.
+		Path: path.Join(config.flags.kubeletRegistrarDirectoryPath, consts.DriverName+"-reg.sock"),
+	}).String()
+	log.Info("connecting to registration socket", "path", regSockPath)
+	regConn, err := grpc.NewClient(
+		regSockPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect to registration socket: %w", err)
+	}
+
+	draSockPath := (&url.URL{
+		Scheme: "unix",
+		Path:   path.Join(config.DriverPluginPath(), "dra.sock"),
+	}).String()
+	log.Info("connecting to DRA socket", "path", draSockPath)
+	draConn, err := grpc.NewClient(
+		draSockPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect to DRA socket: %w", err)
+	}
+
+	server := grpc.NewServer()
+	healthcheck := &healthcheck{
+		server:    server,
+		regClient: registerapi.NewRegistrationClient(regConn),
+		draClient: drapb.NewDRAPluginClient(draConn),
+	}
+	grpc_health_v1.RegisterHealthServer(server, healthcheck)
+
+	healthcheck.wg.Add(1)
+	go func() {
+		defer healthcheck.wg.Done()
+		log.Info("starting healthcheck service", "addr", lis.Addr().String())
+		if err := server.Serve(lis); err != nil {
+			log.Error(err, "failed to serve healthcheck service", "addr", addr)
+		}
+	}()
+
+	return healthcheck, nil
+}
+
+func (h *healthcheck) Stop(logger klog.Logger) {
+	if h.server != nil {
+		logger.Info("stopping healthcheck service")
+		h.server.GracefulStop()
+	}
+	h.wg.Wait()
+}
+
+// Check implements [grpc_health_v1.HealthServer].
+func (h *healthcheck) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	log := klog.FromContext(ctx)
+
+	knownServices := map[string]struct{}{"": {}, "liveness": {}}
+	if _, known := knownServices[req.GetService()]; !known {
+		return nil, status.Error(codes.NotFound, "unknown service")
+	}
+
+	status := &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+	}
+
+	info, err := h.regClient.GetInfo(ctx, &registerapi.InfoRequest{})
+	if err != nil {
+		log.Error(err, "failed to call GetInfo")
+		return status, nil
+	}
+	log.V(5).Info("Successfully invoked GetInfo", "info", info)
+
+	_, err = h.draClient.NodePrepareResources(ctx, &drapb.NodePrepareResourcesRequest{})
+	if err != nil {
+		log.Error(err, "failed to call NodePrepareResources")
+		return status, nil
+	}
+	log.V(5).Info("Successfully invoked NodePrepareResources")
+
+	status.Status = grpc_health_v1.HealthCheckResponse_SERVING
+	return status, nil
+}

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -45,6 +45,19 @@ spec:
         command: ["dra-example-kubeletplugin"]
         resources:
           {{- toYaml .Values.kubeletPlugin.containers.plugin.resources | nindent 10 }}
+        {{/*
+          A literal "0" will allocate a random port. Don't configure the probe
+          with the same literal "0" since that won't match where the service is
+          actually running.
+        */}}
+        {{- if (gt (int .Values.kubeletPlugin.containers.plugin.healthcheckPort) 0) }}
+        livenessProbe:
+          grpc:
+            port: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort }}
+            service: liveness
+          failureThreshold: 3
+          periodSeconds: 10
+        {{- end }}
         env:
         - name: CDI_ROOT
           value: /var/run/cdi
@@ -63,6 +76,10 @@ spec:
         # Simulated number of devices the example driver will pretend to have.
         - name: NUM_DEVICES
           value: "9"
+        {{- if .Values.kubeletPlugin.containers.plugin.healthcheckPort }}
+        - name: HEALTHCHECK_PORT
+          value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}
+        {{- end }}
         volumeMounts:
         - name: plugins-registry
           mountPath: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -63,6 +63,9 @@ kubeletPlugin:
       securityContext:
         privileged: true
       resources: {}
+      # Port running a gRPC health service checked by a livenessProbe.
+      # Set to a negative value to disable the service and the probe.
+      healthcheckPort: 51515
 
 webhook:
   enabled: false

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.25.3
+	google.golang.org/grpc v1.68.1
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
@@ -72,7 +73,6 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
-	google.golang.org/grpc v1.68.1 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
This PR adds a gRPC livenessProbe to the kubelet plugin which invokes both the registration socket's GetInfo method and the DRA socket's NodePrepareResources method with an empty list of claims.

Fixes #96