### PR TITLE
add initContainer claim-sharing example

### DIFF
--- a/demo/gpu-test6.yaml
+++ b/demo/gpu-test6.yaml
@@ -1,0 +1,48 @@
+# One pod: one initContainer + one container
+# Each asking for shared access to a single GPU
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-test6
+
+---
+apiVersion: resource.k8s.io/v1beta1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: gpu-test6
+  name: single-gpu
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        deviceClassName: gpu.example.com
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: gpu-test6
+  name: pod0
+spec:
+  initContainers:
+  - name: init0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export"]
+    resources:
+      claims:
+      - name: shared-gpu
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: shared-gpu
+  resourceClaims:
+  - name: shared-gpu
+    resourceClaimTemplateName: single-gpu

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         # Simulated number of devices the example driver will pretend to have.
         - name: NUM_DEVICES
-          value: "8"
+          value: "9"
         volumeMounts:
         - name: plugins-registry
           mountPath: /var/lib/kubelet/plugins_registry


### PR DESCRIPTION
This PR adds a new example that demonstrates a pod's initContainer sharing a claim w/ its container.

A potential use of this example would be adding "pre-validation" to a GPU device before performing work.