### PR TITLE
Update kubelet plugin signal handling on shutdown

### DIFF
--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -85,7 +85,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	return driver, nil
 }
 
-func (d *driver) Shutdown(ctx context.Context) error {
+func (d *driver) Shutdown() error {
 	d.helper.Stop()
 	return nil
 }


### PR DESCRIPTION
This PR supersedes #68 to update how shutdown signals are handled by the kubelet plugin. The main difference from that PR is the use of [`signal.NotifyContext`](https://pkg.go.dev/os/signal#NotifyContext) to tie the signal handler to a `Context` instead of managing a channel directly. I haven't observed any functional differences between this PR and either `main` or #68.

Closes #68