### PR TITLE
Make number of simulated devices configurable via Helm

### DIFF
--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         # Simulated number of devices the example driver will pretend to have.
         - name: NUM_DEVICES
-          value: "9"
+          value: {{ .Values.kubeletPlugin.numDevices | quote }}
         {{- if .Values.kubeletPlugin.containers.plugin.healthcheckPort }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -45,6 +45,7 @@ controller:
       resources: {}
 
 kubeletPlugin:
+  numDevices: 8
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -34,5 +34,6 @@ helm upgrade -i \
   --create-namespace \
   --namespace dra-example-driver \
   --set webhook.enabled=true \
+  --set kubeletPlugin.numDevices=9 \
   dra-example-driver \
   deployments/helm/dra-example-driver


### PR DESCRIPTION
Fixes: #108

Replaces hardcoded `NUM_DEVICES` with a configurable value via `values.yaml`. 
Default is 8. 
e2e tests can override this to 9 as needed.