### PR TITLE
fix: support seamless upgrades with pod uid in socket path names + default helm chart values

### DIFF
--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -49,14 +49,13 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.state = state
 
-	helper, err := kubeletplugin.Start(
-		ctx,
-		driver,
+	helper, err := kubeletplugin.Start(ctx, driver,
 		kubeletplugin.KubeClient(config.coreclient),
 		kubeletplugin.NodeName(config.flags.nodeName),
 		kubeletplugin.DriverName(config.flags.driverName),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+		kubeletplugin.RollingUpdate(types.UID(config.flags.podUID)),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/dra-example-kubeletplugin/health.go
+++ b/cmd/dra-example-kubeletplugin/health.go
@@ -61,9 +61,12 @@ func startHealthcheck(ctx context.Context, config *Config) (*healthcheck, error)
 
 	regSockPath := (&url.URL{
 		Scheme: "unix",
-		// TODO: this needs to adapt when seamless upgrades
-		// are enabled and the filename includes a uid.
-		Path: path.Join(config.flags.kubeletRegistrarDirectoryPath, config.flags.driverName+"-reg.sock"),
+		Path: func() string {
+			if config.flags.podUID != "" {
+				return path.Join(config.flags.kubeletRegistrarDirectoryPath, config.flags.driverName+"-"+config.flags.podUID+"-reg.sock")
+			}
+			return path.Join(config.flags.kubeletRegistrarDirectoryPath, config.flags.driverName+"-reg.sock")
+		}(),
 	}).String()
 	log.Info("connecting to registration socket", "path", regSockPath)
 	regConn, err := grpc.NewClient(
@@ -76,7 +79,12 @@ func startHealthcheck(ctx context.Context, config *Config) (*healthcheck, error)
 
 	draSockPath := (&url.URL{
 		Scheme: "unix",
-		Path:   path.Join(config.DriverPluginPath(), "dra.sock"),
+		Path: func() string {
+			if config.flags.podUID != "" {
+				return path.Join(config.DriverPluginPath(), "dra-"+config.flags.podUID+".sock")
+			}
+			return path.Join(config.DriverPluginPath(), "dra.sock")
+		}(),
 	}).String()
 	log.Info("connecting to DRA socket", "path", draSockPath)
 	draConn, err := grpc.NewClient(

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -52,6 +52,7 @@ type Flags struct {
 	healthcheckPort               int
 	profile                       string
 	driverName                    string
+	podUID                        string
 }
 
 type Config struct {
@@ -146,6 +147,12 @@ func newApp() *cli.App {
 			Usage:       "Name of the DRA driver. Its default is derived from the device profile.",
 			Destination: &flags.driverName,
 			EnvVars:     []string{"DRIVER_NAME"},
+		},
+		&cli.StringFlag{
+			Name:        "pod-uid",
+			Usage:       "UID of the pod (used for seamless upgrades to create unique socket names).",
+			Destination: &flags.podUID,
+			EnvVars:     []string{"POD_UID"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/deployments/helm/dra-example-driver/Chart.yaml
+++ b/deployments/helm/dra-example-driver/Chart.yaml
@@ -25,4 +25,4 @@ version: 0.0.0-dev
 # It is recommended to use it with quotes.
 appVersion: "v0.2.1"
 
-kubeVersion: ">=1.32.0-0"
+kubeVersion: ">=1.33.0-0"

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -84,6 +84,10 @@ spec:
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}
         {{- end }}
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         volumeMounts:
         - name: plugins-registry
           mountPath: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -41,6 +41,11 @@ kubeletPlugin:
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate
+    # for seamless rolling updates, maxSurge can be greater than 0.
+    # See: https://pkg.go.dev/k8s.io/dynamic-resource-allocation/kubeletplugin#RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   podAnnotations: {}
   podSecurityContext: {}
   nodeSelector: {}


### PR DESCRIPTION
Fixes issue #107
Socket path names in the format {baseName}{suffix} works fine for legacy deployments but if we have seamless upgrades (max surge 1 maxUnavailable 0) then it doesn't work because the socket path names include uid {baseName}-{uid}{suffix}.
Without UIDs in socket names: Two pods can't run simultaneously because they'd conflict trying to create the same socket file names. 

Solution:
Include pod UID in socket paths. Define default seamless upgrade values. Chart now defaults to seamless upgrades (max surge 1 maxUnavailable 0) which users can override by setting `kubeletPlugin.updateStrategy.rollingUpdate` values directly.

How to test:
```bash
# Build the kubelet plugin binary with the changes
make cmd-dra-example-kubeletplugin
# in demo dir and build/load image
cd demo
./scripts/build-driver-image.sh
./scripts/load-driver-image-into-kind.sh
cd ..
# made a new namespace
kubectl create namespace dra-example-driver

# Test Default Config where seamless upgrades disabled
helm install dra-example-driver deployments/helm/dra-example-driver --namespace dra-example-driver
# Check deployment
kubectl get pods --namespace dra-example-driver
# I verified DaemonSet update strategy correctly has **maxSurge: 1, maxUnavailable: 0**
# Check logs for legacy socket paths
kubectl logs -n dra-example-driver $POD_NAME | grep -E "(socket|endpoint)"
 
# Upgrade deployment triggering rolling update to enable seamless upgrades
kubectl patch daemonset dra-example-driver-kubeletplugin -n dra-example-driver \
  -p '{"spec":{"template":{"metadata":{"annotations":{"test-rolling-update":"'$(date +%s)'"}}}}}'
# verify uid socket paths in new pods
NEW_POD_NAME=$(kubectl get pods -n dra-example-driver -o jsonpath='{.items[0].metadata.name}')
kubectl logs -n dra-example-driver $NEW_POD_NAME | grep -E "(socket|endpoint)" | head -5

# Test non-seamless (overriding defaults)
helm upgrade dra-example-driver deployments/helm/dra-example-driver \
  --namespace dra-example-driver \
  --set kubeletPlugin.updateStrategy.rollingUpdate.maxSurge=0 \
  --set kubeletPlugin.updateStrategy.rollingUpdate.maxUnavailable=1

# Verify old rolling update strategy {"maxSurge": 0, "maxUnavailable": 1}
kubectl get daemonset dra-example-driver-kubeletplugin -n dra-example-driver \
  -o jsonpath='{.spec.updateStrategy.rollingUpdate}' | jq .
```
Results:
Seamless Upgrades Enabled default behavior:
maxSurge: 1, maxUnavailable: 0
```
I0422 23:21:04.522190 1 health.go:71] "connecting to registration socket" path="unix:///var/lib/kubelet/plugins_registry/gpu.example.com-<POD_UID>-reg.sock"
I0422 23:21:04.522536 1 health.go:89] "connecting to DRA socket" path="unix:///var/lib/kubelet/plugins/gpu.example.com/dra-<POD_UID>.sock"
```

Seamless Upgrades Disabled by user overriding helm chart:
maxSurge: 0, maxUnavailable: 1
- socket paths still include pod uid
```
I0422 23:18:56.245888 1 health.go:71] "connecting to registration socket" path="unix:///var/lib/kubelet/plugins_registry/gpu.example.com-<POD_UID>-reg.sock"
I0422 23:18:56.246339 1 health.go:89] "connecting to DRA socket" path="unix:///var/lib/kubelet/plugins/gpu.example.com/dra-<POD_UID>.sock"
```
