### PR TITLE
Add mechanism to pass device attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,55 @@ Finally, you can run the following to cleanup your environment and delete the
 
 ## Anatomy of a DRA resource driver
 
+### Configuration
+
+The DRA example driver supports several configuration options that can be set via command-line flags, environment variables, or Helm values:
+
+#### Device Configuration
+
+- `--num-devices` / `NUM_DEVICES`: The number of mock GPU devices to create (default: 8)
+- `--device-attributes` / `DEVICE_ATTRIBUTES`: Additional device attributes to be added to resource slices in `key=value` format, separated by commas (default: empty)
+
+The driver automatically detects the value type based on the input:
+- **String**: `productName=NVIDIA GeForce RTX 5090`, `architecture=Blackwell` (default)
+
+Example usage:
+```bash
+# Via command line
+./dra-example-kubeletplugin --num-devices=4 --device-attributes="productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
+
+# Via environment variable
+export DEVICE_ATTRIBUTES="productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
+./dra-example-kubeletplugin --num-devices=4
+
+# Via Helm values.yaml
+kubeletPlugin:
+  numDevices: 4
+  deviceAttributes: "productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
+```
+
+The device attributes will be added to each device in the resource slice alongside the default attributes (index, uuid, model, driverVersion). The resulting resource slice will have properly typed attributes:
+
+```yaml
+- attributes:
+    index:
+      int: 0
+    uuid:
+      string: gpu-18db0e85-99e9-c746-8531-ffeb86328b39
+    model:
+      string: LATEST-GPU-MODEL
+    driverVersion:
+      version: 1.0.0
+    productName:                    # <- Custom string attribute
+      string: NVIDIA GeForce RTX 5090
+    architecture:                   # <- Custom string attribute
+      string: Blackwell
+  capacity:
+    memory:
+      value: 80Gi
+  name: gpu-0
+```
+
 TBD
 
 ## Code Organization

--- a/README.md
+++ b/README.md
@@ -377,56 +377,9 @@ Finally, you can run the following to cleanup your environment and delete the
 
 ## Anatomy of a DRA resource driver
 
-### Configuration
-
-The DRA example driver supports several configuration options that can be set via command-line flags, environment variables, or Helm values:
-
-#### Device Configuration
-
-- `--num-devices` / `NUM_DEVICES`: The number of mock GPU devices to create (default: 8)
-- `--device-attributes` / `DEVICE_ATTRIBUTES`: Additional device attributes to be added to resource slices in `key=value` format, separated by commas (default: empty)
-
-The driver automatically detects the value type based on the input:
-- **String**: `productName=NVIDIA GeForce RTX 5090`, `architecture=Blackwell` (default)
-
-Example usage:
-```bash
-# Via command line
-./dra-example-kubeletplugin --num-devices=4 --device-attributes="productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
-
-# Via environment variable
-export DEVICE_ATTRIBUTES="productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
-./dra-example-kubeletplugin --num-devices=4
-
-# Via Helm values.yaml
-kubeletPlugin:
-  numDevices: 4
-  deviceAttributes: "productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
-```
-
-The device attributes will be added to each device in the resource slice alongside the default attributes (index, uuid, model, driverVersion). The resulting resource slice will have properly typed attributes:
-
-```yaml
-- attributes:
-    index:
-      int: 0
-    uuid:
-      string: gpu-18db0e85-99e9-c746-8531-ffeb86328b39
-    model:
-      string: LATEST-GPU-MODEL
-    driverVersion:
-      version: 1.0.0
-    productName:                    # <- Custom string attribute
-      string: NVIDIA GeForce RTX 5090
-    architecture:                   # <- Custom string attribute
-      string: Blackwell
-  capacity:
-    memory:
-      value: 80Gi
-  name: gpu-0
-```
-
-TBD
+For usage and configuration options, prefer:
+- CLI help: run `./dra-example-kubeletplugin --help` for flags and examples
+- Helm values: consult `deployments/helm/dra-example-driver/values.yaml` for configurable settings and inline docs
 
 ## Code Organization
 

--- a/cmd/dra-example-kubeletplugin/discovery_test.go
+++ b/cmd/dra-example-kubeletplugin/discovery_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+func TestParseDeviceAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		wantErr  bool
+		wantVals map[resourceapi.QualifiedName]func(resourceapi.DeviceAttribute) bool
+	}{
+		{
+			name:     "empty",
+			input:    []string{},
+			wantErr:  false,
+			wantVals: map[resourceapi.QualifiedName]func(resourceapi.DeviceAttribute) bool{},
+		},
+		{
+			name:    "invalid format (missing '=')",
+			input:   []string{"invalid"},
+			wantErr: true,
+		},
+		{
+			name:  "typed values",
+			input: []string{"boolTrue=true", "boolFalse=false", "count=42", "driverVersion=1.2.3", "pre=1.0.0-beta.1", "name=LATEST-GPU-MODEL"},
+			wantVals: map[resourceapi.QualifiedName]func(resourceapi.DeviceAttribute) bool{
+				"boolTrue":      func(a resourceapi.DeviceAttribute) bool { return a.BoolValue != nil && *a.BoolValue },
+				"boolFalse":     func(a resourceapi.DeviceAttribute) bool { return a.BoolValue != nil && !*a.BoolValue },
+				"count":         func(a resourceapi.DeviceAttribute) bool { return a.IntValue != nil && *a.IntValue == 42 },
+				"driverVersion": func(a resourceapi.DeviceAttribute) bool { return a.VersionValue != nil && *a.VersionValue == "1.2.3" },
+				"pre": func(a resourceapi.DeviceAttribute) bool {
+					return a.VersionValue != nil && *a.VersionValue == "1.0.0-beta.1"
+				},
+				"name": func(a resourceapi.DeviceAttribute) bool {
+					return a.StringValue != nil && *a.StringValue == "LATEST-GPU-MODEL"
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDeviceAttributes(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for k, check := range tt.wantVals {
+				a, ok := got[k]
+				if !ok {
+					t.Fatalf("missing key %q", k)
+				}
+				if !check(a) {
+					t.Fatalf("value check failed for %q: %+v", k, a)
+				}
+			}
+		})
+	}
+}
+
+func TestIsSemanticVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		v    string
+		ok   bool
+	}{
+		{"basic", "1.2.3", true},
+		{"prerelease", "1.0.0-beta", true},
+		{"prerelease+build", "1.0.0-beta+build", true},
+		{"zeros", "0.0.1", true},
+		{"missing patch", "1.2", false},
+		{"too many parts", "1.2.3.4", false},
+		{"invalid char", "1.0.x", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isSemanticVersion(c.v); got != c.ok {
+				t.Fatalf("isSemanticVersion(%q)=%v, want %v", c.v, got, c.ok)
+			}
+		})
+	}
+}

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -46,7 +46,7 @@ type Flags struct {
 	nodeName                      string
 	cdiRoot                       string
 	numDevices                    int
-	deviceAttributes              string
+	deviceAttributes              []string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
@@ -95,12 +95,11 @@ func newApp() *cli.App {
 			Destination: &flags.numDevices,
 			EnvVars:     []string{"NUM_DEVICES"},
 		},
-		&cli.StringFlag{
-			Name:        "device-attributes",
-			Usage:       "Additional device attributes to be added to resource slices in key=value format, separated by commas. Example: productName=NVIDIA GeForce RTX 5090,architecture=Blackwell",
-			Value:       "",
-			Destination: &flags.deviceAttributes,
-			EnvVars:     []string{"DEVICE_ATTRIBUTES"},
+		&cli.StringSliceFlag{
+			Name:    "device-attributes",
+			Usage:   "Additional device attributes as repeated key=value pairs. May be specified multiple times. Examples: --device-attributes productName=NVIDIA GeForce RTX 5090 --device-attributes architecture=Blackwell. Note: when using DEVICE_ATTRIBUTES env var, provide key=value entries separated by commas; values containing commas are not supported via env and should be passed using repeated --device-attributes flags.",
+			Value:   cli.NewStringSlice(),
+			EnvVars: []string{"DEVICE_ATTRIBUTES"},
 		},
 		&cli.StringFlag{
 			Name:        "kubelet-registrar-directory-path",
@@ -145,6 +144,8 @@ func newApp() *cli.App {
 			if err != nil {
 				return fmt.Errorf("create client: %v", err)
 			}
+
+			flags.deviceAttributes = c.StringSlice("device-attributes")
 
 			config := &Config{
 				flags:      flags,

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -46,6 +46,7 @@ type Flags struct {
 	nodeName                      string
 	cdiRoot                       string
 	numDevices                    int
+	deviceAttributes              string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
@@ -93,6 +94,13 @@ func newApp() *cli.App {
 			Value:       8,
 			Destination: &flags.numDevices,
 			EnvVars:     []string{"NUM_DEVICES"},
+		},
+		&cli.StringFlag{
+			Name:        "device-attributes",
+			Usage:       "Additional device attributes to be added to resource slices in key=value format, separated by commas. Example: productName=NVIDIA GeForce RTX 5090,architecture=Blackwell",
+			Value:       "",
+			Destination: &flags.deviceAttributes,
+			EnvVars:     []string{"DEVICE_ATTRIBUTES"},
 		},
 		&cli.StringFlag{
 			Name:        "kubelet-registrar-directory-path",

--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -64,7 +64,7 @@ type DeviceState struct {
 }
 
 func NewDeviceState(config *Config) (*DeviceState, error) {
-	allocatable, err := enumerateAllPossibleDevices(config.flags.numDevices)
+	allocatable, err := enumerateAllPossibleDevices(config.flags.numDevices, config.flags.deviceAttributes)
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating all possible devices: %v", err)
 	}

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -76,6 +76,9 @@ spec:
         # Simulated number of devices the example driver will pretend to have.
         - name: NUM_DEVICES
           value: {{ .Values.kubeletPlugin.numDevices | quote }}
+        # Additional device attributes to be added to resource slices.
+        - name: DEVICE_ATTRIBUTES
+          value: {{ .Values.kubeletPlugin.deviceAttributes | quote }}
         {{- if .Values.kubeletPlugin.containers.plugin.healthcheckPort }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -46,6 +46,7 @@ controller:
 
 kubeletPlugin:
   numDevices: 8
+  deviceAttributes: ""
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -46,6 +46,12 @@ controller:
 
 kubeletPlugin:
   numDevices: 8
+  # Additional device attributes to be added to resource slices.
+  # When setting via env var (DEVICE_ATTRIBUTES), provide a comma-separated list of key=value entries:
+  #   DEVICE_ATTRIBUTES: "productName=NVIDIA GeForce RTX 5090,architecture=Blackwell"
+  # Values containing commas are not supported via env var. Prefer repeated CLI flags, e.g.:
+  #   --device-attributes productName=NVIDIA GeForce RTX 5090 \
+  #   --device-attributes architecture=Blackwell
   deviceAttributes: ""
   priorityClassName: "system-node-critical"
   updateStrategy:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/google/uuid v1.6.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
This PR adds a mechanism to pass device attributes to emulate the real devices in local test setups.
- Add --device-attributes CLI flag and DEVICE_ATTRIBUTES env var
- Implement automatic type detection for int, bool, version, string values
- Add Helm template support for device attributes configuration