### PR TITLE
feat: add experimental minikube support

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,21 @@ Finally, you can run the following to cleanup your environment and delete the
 ./demo/delete-cluster.sh
 ```
 
+### Experimental minikube support
+In order to run this demo using minikube you can start it via this following
+command:
+
+```bash
+./demo/scripts/create-minikube-cluster.sh
+```
+
+Then install the driver like shown in [demo](#Demo) section.
+
+To delete the cluster you can run:
+```bash
+./demo/scripts/delete-minikube-cluster.sh
+```
+
 ## Device Profiles
 
 The example driver can manage several different kinds of devices to demonstrate

--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -70,3 +70,5 @@ if [[ -z "${CONTAINER_TOOL}" ]]; then
 fi
 
 : ${KIND:="env KIND_EXPERIMENTAL_PROVIDER=${CONTAINER_TOOL} kind"}
+
+: ${MINIKUBE:="minikube --profile=${DRIVER_NAME}-cluster"}

--- a/demo/scripts/create-minikube-cluster.sh
+++ b/demo/scripts/create-minikube-cluster.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script deploys a minikube cluster and modifies its configuration
+# so the resulting cluster has cdi support
+#
+# Usage: create-minikube-cluster.sh
+
+# A reference to the current directory where this script is located
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/common.sh"
+
+
+${MINIKUBE} start \
+    --container-runtime=containerd \
+    --driver=docker \
+    --cni=flannel \
+    --extra-config=apiserver.runtime-config=resource.k8s.io/v1beta1=true
+
+# This adds enable_cdi to config.toml and restarts containerd
+${MINIKUBE} ssh "sudo sed -i '/\[plugins\.\"io\.containerd\.grpc\.v1\.cri\"]/a\    enable_cdi = true' /etc/containerd/config.toml"
+${MINIKUBE} ssh "sudo systemctl restart containerd"

--- a/demo/scripts/delete-minikube-cluster.sh
+++ b/demo/scripts/delete-minikube-cluster.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This scripts invokes `kind build image` so that the resulting
+# image has a containerd with CDI support.
+
+# A reference to the current directory where this script is located
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/common.sh"
+
+${MINIKUBE} delete


### PR DESCRIPTION
Add minikube cluster creation and deletion scripts with CDI support enabled. This provides an alternative to kind for running the DRA example driver demo.

The minikube cluster is configured to use containerd with CDI enabled by modifying /etc/containerd/config.yaml and restarting the containerd service.