### PR TITLE
Add DRAPartitionableDevices support

### DIFF
--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -53,6 +53,7 @@ type Flags struct {
 	profile                       string
 	driverName                    string
 	podUID                        string
+	gpuPartitions                 int
 }
 
 type Config struct {
@@ -65,7 +66,7 @@ type Config struct {
 
 var validProfiles = map[string]func(flags Flags) profiles.Profile{
 	gpu.ProfileName: func(flags Flags) profiles.Profile {
-		return gpu.NewProfile(flags.nodeName, flags.numDevices)
+		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions)
 	},
 }
 
@@ -153,6 +154,13 @@ func newApp() *cli.App {
 			Usage:       "UID of the pod (used for seamless upgrades to create unique socket names).",
 			Destination: &flags.podUID,
 			EnvVars:     []string{"POD_UID"},
+		},
+		&cli.IntFlag{
+			Name:        "gpu-partitions",
+			Usage:       "Number of partitions per GPU. When set to a value greater than 0, GPUs are exposed with shared counters allowing flexible partitioning (DRAPartitionableDevices feature).",
+			Value:       0,
+			Destination: &flags.gpuPartitions,
+			EnvVars:     []string{"GPU_PARTITIONS"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/demo/partitionable-devices.yaml
+++ b/demo/partitionable-devices.yaml
@@ -1,0 +1,71 @@
+# Example: DRA Partitionable Devices
+#
+# This demo shows the DRAPartitionableDevices feature, which allows GPUs to be
+# exposed with shared counters enabling flexible partitioning. Each physical GPU
+# has a counter set (memory and compute), and multiple partition devices consume
+# from those counters. A full-GPU device is also available that consumes all
+# counters.
+#
+# Helm install (required before running this demo):
+#   helm upgrade -i \
+#     --create-namespace \
+#     --namespace dra-example-driver \
+#     --set kubeletPlugin.gpuPartitions=4 \
+#     --set kubeletPlugin.numDevices=2 \
+#     dra-example-driver \
+#     deployments/helm/dra-example-driver
+#
+# Verify ResourceSlices are created (should see two slices per node — one for
+# shared counters and one for partition devices):
+#   kubectl get resourceslices -o wide
+#
+# Expected: pod0 gets two GPU partitions. The scheduler uses shared counters
+# to track that partitions share GPU resources. Check with:
+#   kubectl logs -n partitionable-devices pod0 -c ctr0 | grep GPU_DEVICE
+#
+# Driver requirements:
+#   Profile: gpu
+#   Helm values: kubeletPlugin.gpuPartitions=4
+#
+# Cluster requirements:
+#   Kubernetes 1.35+ with feature gate DRAPartitionableDevices enabled
+#   (Beta and enabled by default in 1.36+)
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: partitionable-devices
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: partitionable-devices
+  name: gpu-partitions
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu-partition
+        exactly:
+          deviceClassName: gpu.example.com
+          count: 2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: partitionable-devices
+  name: pod0
+spec:
+  restartPolicy: Never
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu-partitions
+  resourceClaims:
+  - name: gpu-partitions
+    resourceClaimTemplateName: gpu-partitions

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -84,6 +84,8 @@ spec:
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}
         {{- end }}
+        - name: GPU_PARTITIONS
+          value: {{ .Values.kubeletPlugin.gpuPartitions | quote }}
         - name: POD_UID
           valueFrom:
             fieldRef:

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -38,6 +38,10 @@ kubeletPlugin:
   # numDevices describes how many GPUs to advertise on each node when the "gpu"
   # deviceProfile is used. Not relevant for other profiles.
   numDevices: 8
+  # gpuPartitions sets the number of partitions per GPU. When set to a value
+  # greater than 0, GPUs are exposed with shared counters allowing flexible
+  # partitioning (DRAPartitionableDevices feature). 0 disables partitioning.
+  gpuPartitions: 0
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate

--- a/internal/profiles/gpu/gpu.go
+++ b/internal/profiles/gpu/gpu.go
@@ -18,7 +18,9 @@ package gpu
 
 import (
 	"fmt"
+	"maps"
 	"math/rand"
+	"strings"
 
 	"github.com/google/uuid"
 	resourceapi "k8s.io/api/resource/v1"
@@ -36,14 +38,16 @@ import (
 const ProfileName = "gpu"
 
 type Profile struct {
-	nodeName string
-	numGPUs  int
+	nodeName         string
+	numGPUs          int
+	partitionsPerGPU int
 }
 
-func NewProfile(nodeName string, numGPUs int) Profile {
+func NewProfile(nodeName string, numGPUs int, partitionsPerGPU int) Profile {
 	return Profile{
-		nodeName: nodeName,
-		numGPUs:  numGPUs,
+		nodeName:         nodeName,
+		numGPUs:          numGPUs,
+		partitionsPerGPU: partitionsPerGPU,
 	}
 }
 
@@ -51,41 +55,129 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 	seed := p.nodeName
 	uuids := generateUUIDs(seed, p.numGPUs)
 
+	memoryPerGPU := resource.MustParse("80Gi")
+	computePerGPU := resource.MustParse("100")
+
 	var devices []resourceapi.Device
+	var sharedCounters []resourceapi.CounterSet
+
+	var partitionMemory, partitionCompute resource.Quantity
+	if p.partitionsPerGPU > 0 {
+		partitionMemory = *resource.NewQuantity(memoryPerGPU.Value()/int64(p.partitionsPerGPU), resource.BinarySI)
+		partitionCompute = *resource.NewQuantity(computePerGPU.Value()/int64(p.partitionsPerGPU), resource.DecimalSI)
+	}
+
 	for i, uuid := range uuids {
-		device := resourceapi.Device{
-			Name: fmt.Sprintf("gpu-%d", i),
-			Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				"index": {
-					IntValue: ptr.To(int64(i)),
-				},
-				"uuid": {
-					StringValue: ptr.To(uuid),
-				},
-				"model": {
-					StringValue: ptr.To("LATEST-GPU-MODEL"),
-				},
-				"driverVersion": {
-					VersionValue: ptr.To("1.0.0"),
-				},
+		attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+			"index": {
+				IntValue: ptr.To(int64(i)),
 			},
-			Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-				"memory": {
-					Value: resource.MustParse("80Gi"),
-				},
+			"uuid": {
+				StringValue: ptr.To(uuid),
+			},
+			"model": {
+				StringValue: ptr.To("LATEST-GPU-MODEL"),
+			},
+			"driverVersion": {
+				VersionValue: ptr.To("1.0.0"),
 			},
 		}
-		devices = append(devices, device)
+
+		if p.partitionsPerGPU > 0 {
+			counterSetName := fmt.Sprintf("gpu-%d-counters", i)
+			sharedCounters = append(sharedCounters, resourceapi.CounterSet{
+				Name: counterSetName,
+				Counters: map[string]resourceapi.Counter{
+					"memory": {
+						Value: memoryPerGPU,
+					},
+					"compute": {
+						Value: computePerGPU,
+					},
+				},
+			})
+
+			for j := 0; j < p.partitionsPerGPU; j++ {
+				partitionAttrs := maps.Clone(attrs)
+				partitionAttrs["partition"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(j))}
+				partitionAttrs["partitionable"] = resourceapi.DeviceAttribute{BoolValue: ptr.To(true)}
+
+				devices = append(devices, resourceapi.Device{
+					Name:       fmt.Sprintf("gpu-%d-partition-%d", i, j),
+					Attributes: partitionAttrs,
+					Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+						"memory": {
+							Value: partitionMemory,
+						},
+					},
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: counterSetName,
+							Counters: map[string]resourceapi.Counter{
+								"memory": {
+									Value: partitionMemory,
+								},
+								"compute": {
+									Value: partitionCompute,
+								},
+							},
+						},
+					},
+				})
+			}
+
+			// Full GPU device that consumes all resources from the counter set
+			fullAttrs := maps.Clone(attrs)
+			fullAttrs["partitionable"] = resourceapi.DeviceAttribute{BoolValue: ptr.To(true)}
+			fullAttrs["full"] = resourceapi.DeviceAttribute{BoolValue: ptr.To(true)}
+
+			devices = append(devices, resourceapi.Device{
+				Name:       fmt.Sprintf("gpu-%d-full", i),
+				Attributes: fullAttrs,
+				Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+					"memory": {
+						Value: memoryPerGPU,
+					},
+				},
+				ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+					{
+						CounterSet: counterSetName,
+						Counters: map[string]resourceapi.Counter{
+							"memory": {
+								Value: memoryPerGPU,
+							},
+							"compute": {
+								Value: computePerGPU,
+							},
+						},
+					},
+				},
+			})
+		} else {
+			devices = append(devices, resourceapi.Device{
+				Name:       fmt.Sprintf("gpu-%d", i),
+				Attributes: attrs,
+				Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+					"memory": {
+						Value: memoryPerGPU,
+					},
+				},
+			})
+		}
+	}
+
+	slices := []resourceslice.Slice{{Devices: devices}}
+	if len(sharedCounters) > 0 {
+		slices = []resourceslice.Slice{
+			{SharedCounters: sharedCounters},
+			{Devices: devices},
+		}
 	}
 
 	resources := resourceslice.DriverResources{
 		Pools: map[string]resourceslice.Pool{
 			p.nodeName: {
-				Slices: []resourceslice.Slice{
-					{
-						Devices: devices,
-					},
-				},
+				Slices: slices,
 			},
 		},
 	}
@@ -142,6 +234,10 @@ func (p Profile) ApplyConfig(config runtime.Object, results []*resourceapi.Devic
 	return nil, fmt.Errorf("runtime object is not a recognized configuration")
 }
 
+func envVarSafeID(id string) string {
+	return strings.ToUpper(strings.ReplaceAll(id, "-", "_"))
+}
+
 // In this example driver there is no actual configuration applied. We simply
 // define a set of environment variables to be injected into the containers
 // that include a given device. A real driver would likely need to do some sort
@@ -160,12 +256,14 @@ func applyGpuConfig(config *configapi.GpuConfig, results []*resourceapi.DeviceRe
 	}
 
 	for _, result := range results {
+		// Device names are prefixed with "gpu-" (e.g. "gpu-0", "gpu-0-partition-1", "gpu-0-full").
+		envID := envVarSafeID(result.Device[4:])
 		envs := []string{
-			fmt.Sprintf("GPU_DEVICE_%s=%s", result.Device[4:], result.Device),
+			fmt.Sprintf("GPU_DEVICE_%s=%s", envID, result.Device),
 		}
 
 		if config.Sharing != nil {
-			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_SHARING_STRATEGY=%s", result.Device[4:], config.Sharing.Strategy))
+			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_SHARING_STRATEGY=%s", envID, config.Sharing.Strategy))
 		}
 
 		switch {
@@ -174,13 +272,13 @@ func applyGpuConfig(config *configapi.GpuConfig, results []*resourceapi.DeviceRe
 			if err != nil {
 				return nil, fmt.Errorf("unable to get time slicing config for device %v: %w", result.Device, err)
 			}
-			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_TIMESLICE_INTERVAL=%v", result.Device[4:], tsconfig.Interval))
+			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_TIMESLICE_INTERVAL=%v", envID, tsconfig.Interval))
 		case config.Sharing.IsSpacePartitioning():
 			spconfig, err := config.Sharing.GetSpacePartitioningConfig()
 			if err != nil {
 				return nil, fmt.Errorf("unable to get space partitioning config for device %v: %w", result.Device, err)
 			}
-			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_PARTITION_COUNT=%v", result.Device[4:], spconfig.PartitionCount))
+			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_PARTITION_COUNT=%v", envID, spconfig.PartitionCount))
 		}
 
 		edits := &cdispec.ContainerEdits{

--- a/internal/profiles/gpu/gpu_test.go
+++ b/internal/profiles/gpu/gpu_test.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestNewProfile(t *testing.T) {
+	profile := NewProfile("test-node", 4, 0)
+
+	assert.Equal(t, "test-node", profile.nodeName)
+	assert.Equal(t, 4, profile.numGPUs)
+	assert.Equal(t, 0, profile.partitionsPerGPU)
+}
+
+func TestNewProfile_WithPartitions(t *testing.T) {
+	profile := NewProfile("test-node", 2, 4)
+
+	assert.Equal(t, "test-node", profile.nodeName)
+	assert.Equal(t, 2, profile.numGPUs)
+	assert.Equal(t, 4, profile.partitionsPerGPU)
+}
+
+func TestEnumerateDevices_Standard(t *testing.T) {
+	profile := NewProfile("test-node", 2, 0)
+
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	// Should have one pool for the node
+	require.Contains(t, resources.Pools, "test-node")
+	pool := resources.Pools["test-node"]
+
+	// Should have one slice
+	require.Len(t, pool.Slices, 1)
+	slice := pool.Slices[0]
+
+	// Should have 2 devices (one per GPU)
+	require.Len(t, slice.Devices, 2)
+
+	// Verify device names
+	assert.Equal(t, "gpu-0", slice.Devices[0].Name)
+	assert.Equal(t, "gpu-1", slice.Devices[1].Name)
+
+	// Verify no shared counters in standard mode
+	assert.Empty(t, slice.SharedCounters)
+
+	// Verify no ConsumesCounters in standard mode
+	assert.Empty(t, slice.Devices[0].ConsumesCounters)
+	assert.Empty(t, slice.Devices[1].ConsumesCounters)
+
+	// Verify device attributes
+	for i, device := range slice.Devices {
+		assert.NotNil(t, device.Attributes["index"].IntValue)
+		assert.Equal(t, int64(i), *device.Attributes["index"].IntValue)
+		assert.NotNil(t, device.Attributes["uuid"].StringValue)
+		assert.NotNil(t, device.Attributes["model"].StringValue)
+		assert.Equal(t, "LATEST-GPU-MODEL", *device.Attributes["model"].StringValue)
+
+		// Verify capacity
+		memoryKey := resourceapi.QualifiedName("memory")
+		assert.Contains(t, device.Capacity, memoryKey)
+		assert.Equal(t, resource.MustParse("80Gi"), device.Capacity[memoryKey].Value)
+	}
+}
+
+func TestEnumerateDevices_Partitionable(t *testing.T) {
+	profile := NewProfile("test-node", 2, 4)
+
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	// Should have one pool for the node
+	require.Contains(t, resources.Pools, "test-node")
+	pool := resources.Pools["test-node"]
+
+	// Should have two slices: one for shared counters, one for devices
+	require.Len(t, pool.Slices, 2)
+	counterSlice := pool.Slices[0]
+	deviceSlice := pool.Slices[1]
+
+	// Should have shared counters (one per GPU) in counter slice
+	require.Len(t, counterSlice.SharedCounters, 2)
+	assert.Empty(t, counterSlice.Devices)
+
+	// Verify counter set names and values
+	for i, counterSet := range counterSlice.SharedCounters {
+		assert.Equal(t, "gpu-"+string(rune('0'+i))+"-counters", counterSet.Name)
+		assert.Contains(t, counterSet.Counters, "memory")
+		assert.Contains(t, counterSet.Counters, "compute")
+		assert.Equal(t, resource.MustParse("80Gi"), counterSet.Counters["memory"].Value)
+		assert.Equal(t, resource.MustParse("100"), counterSet.Counters["compute"].Value)
+	}
+
+	// Should have devices in device slice: 4 partitions + 1 full per GPU = 10 total
+	require.Len(t, deviceSlice.Devices, 10)
+	assert.Empty(t, deviceSlice.SharedCounters)
+
+	// Count partition devices and full devices
+	partitionCount := 0
+	fullCount := 0
+	for _, device := range deviceSlice.Devices {
+		if fullAttr, exists := device.Attributes["full"]; exists && fullAttr.BoolValue != nil && *fullAttr.BoolValue {
+			fullCount++
+		} else {
+			partitionCount++
+		}
+	}
+	assert.Equal(t, 8, partitionCount) // 4 partitions * 2 GPUs
+	assert.Equal(t, 2, fullCount)      // 1 full device * 2 GPUs
+}
+
+func TestEnumerateDevices_PartitionableDeviceAttributes(t *testing.T) {
+	profile := NewProfile("test-node", 1, 2)
+
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	// Devices are in the second slice (first is counters)
+	deviceSlice := resources.Pools["test-node"].Slices[1]
+
+	// Should have 3 devices: 2 partitions + 1 full
+	require.Len(t, deviceSlice.Devices, 3)
+
+	// Check partition devices
+	for i := 0; i < 2; i++ {
+		device := deviceSlice.Devices[i]
+		assert.Equal(t, "gpu-0-partition-"+string(rune('0'+i)), device.Name)
+
+		// Verify partitionable attribute
+		assert.NotNil(t, device.Attributes["partitionable"])
+		assert.True(t, *device.Attributes["partitionable"].BoolValue)
+
+		// Verify partition index
+		assert.NotNil(t, device.Attributes["partition"])
+		assert.Equal(t, int64(i), *device.Attributes["partition"].IntValue)
+
+		// Verify ConsumesCounters
+		require.Len(t, device.ConsumesCounters, 1)
+		assert.Equal(t, "gpu-0-counters", device.ConsumesCounters[0].CounterSet)
+		assert.Contains(t, device.ConsumesCounters[0].Counters, "memory")
+		assert.Contains(t, device.ConsumesCounters[0].Counters, "compute")
+
+		// Verify partition gets 1/2 of resources (2 partitions)
+		expectedMemory := resource.MustParse("40Gi") // 80Gi / 2
+		expectedCompute := resource.MustParse("50")  // 100 / 2
+		actualMemory := device.ConsumesCounters[0].Counters["memory"].Value
+		actualCompute := device.ConsumesCounters[0].Counters["compute"].Value
+		assert.Equal(t, expectedMemory.Value(), actualMemory.Value())
+		assert.Equal(t, expectedCompute.Value(), actualCompute.Value())
+	}
+
+	// Check full device
+	fullDevice := deviceSlice.Devices[2]
+	assert.Equal(t, "gpu-0-full", fullDevice.Name)
+	assert.NotNil(t, fullDevice.Attributes["full"])
+	assert.True(t, *fullDevice.Attributes["full"].BoolValue)
+
+	// Full device should consume all resources
+	require.Len(t, fullDevice.ConsumesCounters, 1)
+	assert.Equal(t, resource.MustParse("80Gi"), fullDevice.ConsumesCounters[0].Counters["memory"].Value)
+	assert.Equal(t, resource.MustParse("100"), fullDevice.ConsumesCounters[0].Counters["compute"].Value)
+}
+
+func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
+	// UUIDs should be consistent for the same node name
+	profile1 := NewProfile("test-node", 2, 0)
+	profile2 := NewProfile("test-node", 2, 0)
+
+	resources1, err := profile1.EnumerateDevices()
+	require.NoError(t, err)
+	resources2, err := profile2.EnumerateDevices()
+	require.NoError(t, err)
+
+	slice1 := resources1.Pools["test-node"].Slices[0]
+	slice2 := resources2.Pools["test-node"].Slices[0]
+
+	for i := range slice1.Devices {
+		uuid1 := *slice1.Devices[i].Attributes["uuid"].StringValue
+		uuid2 := *slice2.Devices[i].Attributes["uuid"].StringValue
+		assert.Equal(t, uuid1, uuid2, "UUIDs should be consistent for the same node")
+	}
+}
+
+func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
+	profile1 := NewProfile("node-1", 1, 0)
+	profile2 := NewProfile("node-2", 1, 0)
+
+	resources1, err := profile1.EnumerateDevices()
+	require.NoError(t, err)
+	resources2, err := profile2.EnumerateDevices()
+	require.NoError(t, err)
+
+	uuid1 := *resources1.Pools["node-1"].Slices[0].Devices[0].Attributes["uuid"].StringValue
+	uuid2 := *resources2.Pools["node-2"].Slices[0].Devices[0].Attributes["uuid"].StringValue
+
+	assert.NotEqual(t, uuid1, uuid2, "Different nodes should have different UUIDs")
+}

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -25,8 +25,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,8 +69,8 @@ const (
 )
 
 var (
-	gpuDeviceRegexp = regexp.MustCompile(`(?m)^declare -x GPU_DEVICE_[0-9]+="(.+)"$`)
-	gpuIDRegexp     = regexp.MustCompile(`^gpu-([0-9]+)$`)
+	gpuDeviceRegexp = regexp.MustCompile(`(?m)^declare -x GPU_DEVICE_[A-Z0-9_]+="(gpu-.+)"$`)
+	gpuIDRegexp     = regexp.MustCompile(`^gpu-(.+)$`)
 )
 
 func TestE2e(t *testing.T) {
@@ -456,7 +458,7 @@ func extractGPUProperty(logs string, id string, property string) string {
 func getGPUID(gpu string) string {
 	matches := gpuIDRegexp.FindAllStringSubmatch(gpu, -1)
 	if len(matches) > 0 && len(matches[0]) > 1 {
-		return matches[0][1]
+		return strings.ToUpper(strings.ReplaceAll(matches[0][1], "-", "_"))
 	}
 	return ""
 }
@@ -525,6 +527,37 @@ func verifyGPUProperties(g Gomega, logs, namespace, podName, containerName strin
 			fmt.Sprintf("Expected Pod %s/%s, container %s to have %s=%s, got %s",
 				namespace, podName, containerName, expectedProperty, expectedPropertyValue, propertyValue))
 	}
+}
+
+func helmUpgradeDriver(args ...string) {
+	GinkgoHelper()
+	baseArgs := []string{
+		"upgrade", "-i",
+		"--namespace", driverNamespace,
+		"--set", "webhook.enabled=true",
+		"--wait",
+	}
+	baseArgs = append(baseArgs, args...)
+	baseArgs = append(baseArgs, "dra-example-driver", filepath.Join(rootDir, "deployments/helm/dra-example-driver"))
+
+	cmd := exec.Command("helm", baseArgs...)
+	output, err := cmd.CombinedOutput()
+	fmt.Fprintf(GinkgoWriter, "helm upgrade output:\n%s\n", string(output))
+	Expect(err).NotTo(HaveOccurred(), "helm upgrade failed: %s", string(output))
+}
+
+func waitForDriverReady(ctx context.Context) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		pods, err := clientset.CoreV1().Pods(driverNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: driverPodSelector,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pods.Items).NotTo(BeEmpty())
+		for _, pod := range pods.Items {
+			g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+		}
+	}, "60s", "2s").Should(Succeed())
 }
 
 // podContainer identifies a specific container in a specific pod.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -216,6 +216,31 @@ var _ = Describe("Test GPU allocation", func() {
 		}
 	})
 
+	It("should allocate partition devices from shared GPU counters", Serial, func(ctx SpecContext) {
+		helmUpgradeDriver(
+			"--set", "kubeletPlugin.gpuPartitions=4",
+			"--set", "kubeletPlugin.numDevices=2",
+		)
+		DeferCleanup(func(ctx SpecContext) {
+			helmUpgradeDriver(
+				"--set", "kubeletPlugin.numDevices=12",
+				"--set", "kubeletPlugin.gpuPartitions=0",
+			)
+		})
+		waitForDriverReady(ctx)
+
+		namespace := "partitionable-devices"
+		pods := []string{"pod0"}
+		containerName := "ctr0"
+		expectedGPUCount := 2
+
+		deployManifest(ctx, namespace, "partitionable-devices.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+
+		observedGPUs := make(map[string]string)
+		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
+	})
+
 	Context("Webhooks", func() {
 		tests := []struct {
 			name     string


### PR DESCRIPTION
## Summary

Adds support for the [DRAPartitionableDevices](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4815-dra-partitionable-devices) feature (Beta in Kubernetes 1.36). Each physical GPU is represented as a `CounterSet` with shared memory and compute counters. Multiple partition devices consume from these counters, enabling flexible GPU partitioning. A full-GPU device is also available that consumes all counters.

## How to test

```bash
# Build the driver image
./demo/build-driver.sh

# Create a kind cluster (uses k8s v1.36.0)
./demo/clusters/kind/create-cluster.sh

# Install with partitionable devices enabled
helm upgrade -i \
  --create-namespace \
  --namespace dra-example-driver \
  --set kubeletPlugin.partitionableDevices=true \
  --set kubeletPlugin.partitionsPerGPU=4 \
  --set kubeletPlugin.numDevices=2 \
  dra-example-driver \
  deployments/helm/dra-example-driver

# Verify ResourceSlices (should see two — one for counters, one for devices)
kubectl get resourceslices -o wide

# Run the demo
kubectl apply -f demo/partitionable-devices.yaml

# Check allocated partitions
kubectl logs -n partitionable-devices pod0 -c ctr0 | grep GPU_DEVICE
```

## Test Report

<details>
<summary>Click to expand test report (kind cluster, k8s v1.36.0)</summary>

**Date:** 2026-05-05
**Kubernetes Version:** v1.36.0
**Test Environment:** kind cluster (`dra-example-driver-cluster`)

### Test Environment Setup

| Component | Details |
|---|---|
| Kind node image | `kindest/node:v1.36.0` (built from source) |
| Cluster nodes | 1 control-plane + 1 worker |
| Driver image | `registry.k8s.io/dra-example-driver/dra-example-driver:v0.2.1` (built from PR branch) |
| Helm values | `partitionableDevices=true`, `partitionsPerGPU=4`, `numDevices=2` |
| Feature gate | `DRAPartitionableDevices` (Beta, default-enabled in v1.36.0) |

### 1. API Type Validation Against k8s v1.36.0 Source

**Result: PASS**

Cross-referenced every API type used in the PR against the Kubernetes v1.36.0 source (`staging/src/k8s.io/api/resource/v1/types.go`):

| Type/Field | Expected | Actual in v1.36.0 | Match |
|---|---|---|---|
| `CounterSet.Name` | `string` | `string` | Yes |
| `CounterSet.Counters` | `map[string]Counter` | `map[string]Counter` | Yes |
| `Counter.Value` | `resource.Quantity` | `resource.Quantity` | Yes |
| `DeviceCounterConsumption.CounterSet` | `string` | `string` | Yes |
| `DeviceCounterConsumption.Counters` | `map[string]Counter` | `map[string]Counter` | Yes |
| `Device.ConsumesCounters` | `[]DeviceCounterConsumption` | `[]DeviceCounterConsumption` | Yes |
| `resourceslice.Slice.SharedCounters` | `[]resourceapi.CounterSet` | `[]resourceapi.CounterSet` | Yes |

### 2. Unit Tests

**Result: PASS**

```
ok   sigs.k8s.io/dra-example-driver/api/example.com/resource/gpu/v1alpha1
ok   sigs.k8s.io/dra-example-driver/cmd/dra-example-kubeletplugin
ok   sigs.k8s.io/dra-example-driver/cmd/dra-example-webhook
ok   sigs.k8s.io/dra-example-driver/internal/profiles/gpu
```

### 3. ResourceSlice Creation

**Result: PASS**

Two separate ResourceSlices created successfully (one for counters, one for devices):

```
$ kubectl get resourceslices -o wide
NAME                                                            DRIVER            POOL
00000-gpu.example.com-dra-example-driver-cluster-worker-l4vwd   gpu.example.com   dra-example-driver-cluster-worker
00001-gpu.example.com-dra-example-driver-cluster-worker-hv7m9   gpu.example.com   dra-example-driver-cluster-worker
```

### 4. SharedCounters Slice Validation

**Result: PASS**

The counter slice correctly contains:

- `gpu-0-counters`: memory=80Gi, compute=100
- `gpu-1-counters`: memory=80Gi, compute=100
- No `devices` field (as required by the API)

### 5. Devices Slice Validation

**Result: PASS**

The device slice correctly contains 10 devices:

| Device | Type | ConsumesCounters | Memory | Compute |
|---|---|---|---|---|
| `gpu-0-partition-0` | partition | `gpu-0-counters` | 20Gi | 25 |
| `gpu-0-partition-1` | partition | `gpu-0-counters` | 20Gi | 25 |
| `gpu-0-partition-2` | partition | `gpu-0-counters` | 20Gi | 25 |
| `gpu-0-partition-3` | partition | `gpu-0-counters` | 20Gi | 25 |
| `gpu-0-full` | full GPU | `gpu-0-counters` | 80Gi | 100 |
| `gpu-1-partition-0` | partition | `gpu-1-counters` | 20Gi | 25 |
| `gpu-1-partition-1` | partition | `gpu-1-counters` | 20Gi | 25 |
| `gpu-1-partition-2` | partition | `gpu-1-counters` | 20Gi | 25 |
| `gpu-1-partition-3` | partition | `gpu-1-counters` | 20Gi | 25 |
| `gpu-1-full` | full GPU | `gpu-1-counters` | 80Gi | 100 |

### 6. Scheduler Allocation with Shared Counters

**Result: PASS**

Created a `ResourceClaim` requesting 2 devices. The scheduler successfully allocated two partition devices from the same physical GPU:

```yaml
status:
  allocation:
    devices:
      results:
      - device: gpu-0-partition-0
        pool: dra-example-driver-cluster-worker
      - device: gpu-0-partition-1
        pool: dra-example-driver-cluster-worker
```

### 7. Container Environment Variable Injection

**Result: PASS**

The test pod received the expected GPU environment variables:

```
GPU_DEVICE_0-partition-0=gpu-0-partition-0
GPU_DEVICE_0-partition-1=gpu-0-partition-1
GPU_DEVICE_0-partition-0_SHARING_STRATEGY=TimeSlicing
GPU_DEVICE_0-partition-1_SHARING_STRATEGY=TimeSlicing
GPU_DEVICE_0-partition-0_TIMESLICE_INTERVAL=Default
GPU_DEVICE_0-partition-1_TIMESLICE_INTERVAL=Default
```

</details>
