### PR TITLE
Use SHAs for GitHub Actions versions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.25.5
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build
       run: make PREFIX=artifacts cmds
     - name: install helm and kubectl

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
         version: latest
         args: -v --timeout 5m

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.version }}
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build
       run: make PREFIX=artifacts cmds
     - name: List binaries


### PR DESCRIPTION
This error [started appearing](https://github.com/kubernetes-sigs/dra-example-driver/actions/runs/24581545025/job/71880407642?pr=148) on GitHub Actions runs:
> Error: The actions actions/checkout@v6 and golangci/golangci-lint-action@v9 are not allowed in kubernetes-sigs/dra-example-driver because all actions must be pinned to a full-length commit SHA.

This uses commit SHAs matching the latest tagged release for each of the actions we import in our workflows.