### PR TITLE
Fix Dockerfile FromAsCasing warning in build stage

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GOLANG_VERSION=undefined
 ARG BASE_IMAGE=undefined
-FROM golang:${GOLANG_VERSION} as build
+FROM golang:${GOLANG_VERSION} AS build
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
## Summary
- Fix Dockerfile keyword casing in the build instruction
- Change `FROM ... as build` to `FROM ... AS build` in `deployments/container/Dockerfile`
- Remove the `FromAsCasing` warning from container build logs

Fixes #165 

## Why
Build output currently includes a style/lint warning:
`FromAsCasing: 'as' and 'FROM' keywords' casing do not match`.

This PR makes Dockerfile keyword casing consistent and keeps build logs clean.

## Scope
- Non-functional change only (style/lint cleanup)
- No expected runtime or image behavior changes

## Validation
- Build parses Dockerfile without `FromAsCasing` warning after this change.