### PR TITLE
feat(build): support multi-arch image push (amd64/arm64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,5 +182,4 @@ push-release-artifacts:
 		HELM=$(HELM) \
 		demo/scripts/push-driver-chart.sh
 	export DRIVER_IMAGE_TAG="${IMAGE_GIT_TAG}"; \
-	demo/scripts/build-driver-image.sh && \
 	demo/scripts/push-driver-image.sh

--- a/README.md
+++ b/README.md
@@ -50,6 +50,84 @@ From here we will build the image for the example resource driver:
 ./demo/build-driver.sh
 ```
 
+### Container image make recipes
+
+The image build logic lives in `deployments/container/Makefile`.
+If variables are not provided, defaults are:
+
+- `IMAGE_NAME=registry.example.com/dra-example-driver`
+- `VERSION=latest`
+- `PLATFORMS=<current host platform>` (for example `linux/amd64`, `linux/arm64`, or `linux/ppc64le`) when `PLATFORMS` is **unset**
+- `CONTAINER_TOOL=docker`
+
+For demo scripts, `PLATFORMS` is the canonical variable and `DRIVER_IMAGE_PLATFORMS`
+is only a backward compatible fallback. Setting both is treated as an error.
+
+`cloudbuild.yaml` and `demo/scripts/push-driver-image.sh` may provide different
+`PLATFORMS` defaults depending on the workflow:
+
+1. **If `PLATFORMS` is set (e.g. by `cloudbuild.yaml`)**, the Makefile uses it as-is.
+2. **If `PLATFORMS` is unset**, `demo/scripts/push-driver-image.sh` fills a fallback
+   (currently `linux/amd64,linux/arm64,linux/ppc64le`) and `deployments/container/Makefile`
+   falls back to the host platform.
+3. **If `PLATFORMS` is set to an empty string**, `deployments/container/Makefile` fails
+   with a clear error (to avoid confusing silent buildx behavior).
+
+- Build a single-arch image with the standard Docker/Podman build flow:
+  ```bash
+  make -f deployments/container/Makefile build VERSION=<tag> IMAGE_NAME=<name|registry/name> CONTAINER_TOOL=<docker|podman>
+  ```
+- Build for specific platform(s):
+  ```bash
+  make -f deployments/container/Makefile build VERSION=<tag> IMAGE_NAME=<name|registry/name> CONTAINER_TOOL=docker PLATFORMS='linux/amd64,linux/arm64'
+  ```
+- Push for current platform:
+  ```bash
+  make -f deployments/container/Makefile push VERSION=<tag> IMAGE_NAME=<registry/name> CONTAINER_TOOL=<docker|podman>
+  ```
+- Push for specific platform(s):
+  ```bash
+  make -f deployments/container/Makefile push VERSION=<tag> IMAGE_NAME=<registry/name> CONTAINER_TOOL=docker PLATFORMS='linux/amd64,linux/arm64'
+  ```
+
+For Docker, `build` with multiple platforms performs a Buildx build without loading an image into the local Docker daemon; use `push` to publish multi-arch images.
+
+#### Multi-platform builds on Linux (amd64)
+
+Building for a platform other than your host CPU (for example `linux/arm64` on an
+`x86_64` machine) requires Docker Buildx to **run** container steps for that
+architecture during the image build. That needs either native hardware or
+userspace emulation via [QEMU and `binfmt_misc`](https://docs.docker.com/build/building/multi-platform/#qemu).
+
+- **Docker Desktop** (macOS/Windows) and many CI images ship with this enabled.
+- **Linux on amd64** often does not. The same applies to an explicit single
+  platform that does not match the host (for example `PLATFORMS=linux/arm64` on
+  x86_64): the Makefile uses buildx for that case. If a build fails with
+  `exec format error` on an `linux/arm64` step, install emulation support:
+
+  ```bash
+  docker run --privileged --rm tonistiigi/binfmt --install all
+  ```
+
+  Then create or bootstrap a buildx builder (`build` and `push` do this
+  automatically via `ensure-buildx-builder` for multi-platform or cross-platform
+  single-platform builds):
+
+  ```bash
+  make -f deployments/container/Makefile ensure-buildx-builder
+  ```
+
+  Verify with:
+
+  ```bash
+  docker run --rm --platform linux/arm64 alpine uname -m
+  ```
+
+  The output should be `aarch64`.
+
+On Apple Silicon, single-arch `linux/arm64` builds work natively; building
+`linux/amd64` uses emulation the same way.
+
 And create a `kind` cluster to run it in:
 ```bash
 ./demo/clusters/kind/create-cluster.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,7 @@ steps:
   entrypoint: make
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
+  - PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le
   - DRIVER_CHART_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver/charts
   args:
     - push-release-artifacts

--- a/demo/build-driver.sh
+++ b/demo/build-driver.sh
@@ -26,6 +26,7 @@ set -ex
 set -o pipefail
 
 source "${CURRENT_DIR}/scripts/common.sh"
+check_demo_config || exit 1
 
 # Build the example driver image
 ${SCRIPTS_DIR}/build-driver-image.sh

--- a/demo/scripts/build-driver-image.sh
+++ b/demo/scripts/build-driver-image.sh
@@ -26,6 +26,7 @@ set -ex
 set -o pipefail
 
 source "${CURRENT_DIR}/common.sh"
+check_demo_config || exit 1
 
 # Create a temorary directory to hold all the artifacts we need for building the image
 TMP_DIR="$(mktemp -d)"
@@ -43,6 +44,7 @@ export IMAGE="${DRIVER_IMAGE_NAME}"
 export VERSION="${DRIVER_IMAGE_TAG}"
 export CONTAINER_TOOL="${CONTAINER_TOOL}"
 
-# Regenerate the CRDs and build the container image
+# Regenerate the CRDs and build the container image locally (demo / kind workflow).
 make docker-generate
-make -f deployments/container/Makefile "${DRIVER_IMAGE_PLATFORM}"
+
+make -f deployments/container/Makefile "${DRIVER_IMAGE_OS}"

--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -29,7 +29,18 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 : ${DRIVER_IMAGE_REGISTRY:="registry.k8s.io/dra-example-driver"}
 : ${DRIVER_IMAGE_NAME:="${DRIVER_NAME}"}
 : ${DRIVER_IMAGE_TAG:="$(cat $(git rev-parse --show-toplevel)/deployments/helm/${DRIVER_NAME}/Chart.yaml | grep appVersion | sed 's/"//g' | sed -n 's/^appVersion: //p')"}
-: ${DRIVER_IMAGE_PLATFORM:="ubuntu22.04"}
+# Use DRIVER_IMAGE_OS as the canonical variable name.
+# DRIVER_IMAGE_PLATFORM is a deprecated compatibility fallback.
+if [[ -n "${DRIVER_IMAGE_PLATFORM:-}" && -z "${DRIVER_IMAGE_OS:-}" ]]; then
+    DRIVER_IMAGE_OS="${DRIVER_IMAGE_PLATFORM}"
+fi
+: ${DRIVER_IMAGE_OS:="ubuntu22.04"}
+
+# Use PLATFORMS as the canonical variable name.
+# DRIVER_IMAGE_PLATFORMS is a deprecated compatibility fallback.
+if [[ -z "${PLATFORMS:-}" && -n "${DRIVER_IMAGE_PLATFORMS:-}" ]]; then
+    PLATFORMS="${DRIVER_IMAGE_PLATFORMS}"
+fi
 
 # The kubernetes repo to build the kind cluster from
 : ${KIND_K8S_REPO:="https://github.com/kubernetes/kubernetes.git"}
@@ -65,3 +76,23 @@ if [[ -z "${CONTAINER_TOOL}" ]]; then
 fi
 
 : ${KIND:="env KIND_EXPERIMENTAL_PROVIDER=${CONTAINER_TOOL} kind"}
+
+# check_demo_config validates image-build env (DRIVER_IMAGE_OS/PLATFORM and
+# explicit PLATFORMS settings). Call from image build/push scripts only, after
+# sourcing this file.
+check_demo_config() {
+    if [[ -n "${DRIVER_IMAGE_PLATFORM:-}" && -n "${DRIVER_IMAGE_OS:-}" && "${DRIVER_IMAGE_PLATFORM}" != "${DRIVER_IMAGE_OS}" ]]; then
+        echo "Both DRIVER_IMAGE_PLATFORM and DRIVER_IMAGE_OS are set with different values."
+        echo "Use DRIVER_IMAGE_OS only, or set both to the same value."
+        return 1
+    fi
+    if [[ -n "${PLATFORMS:-}" && -n "${DRIVER_IMAGE_PLATFORMS:-}" ]]; then
+        echo "Both PLATFORMS and DRIVER_IMAGE_PLATFORMS are set."
+        echo "Use PLATFORMS only. DRIVER_IMAGE_PLATFORMS is deprecated."
+        return 1
+    fi
+    if [[ -z "${CONTAINER_TOOL}" ]]; then
+        echo "No container tool detected. Please install Docker or Podman."
+        return 1
+    fi
+}

--- a/demo/scripts/push-driver-image.sh
+++ b/demo/scripts/push-driver-image.sh
@@ -20,12 +20,21 @@ CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 set -ex
 set -o pipefail
 
+
 source "${CURRENT_DIR}/common.sh"
+check_demo_config || exit 1
+
+cd "${CURRENT_DIR}/../.."
 
 # Set build variables
+: "${PLATFORMS:=linux/amd64,linux/arm64,linux/ppc64le}"
 export REGISTRY="${DRIVER_IMAGE_REGISTRY}"
 export IMAGE="${DRIVER_IMAGE_NAME}"
 export VERSION="${DRIVER_IMAGE_TAG}"
+export PLATFORMS
 export CONTAINER_TOOL="${CONTAINER_TOOL}"
+
+# Regenerate CRDs/deepcopy in the repo's devel container (root Makefile docker-% target).
+make docker-generate
 
 make -f deployments/container/Makefile push

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -17,27 +17,134 @@ CONTAINER_TOOL ?= docker
 MKDIR ?= mkdir
 DISTRIBUTIONS := ubuntu22.04
 DOCKERFILE := $(CURDIR)/deployments/container/Dockerfile
+SELF_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+COMMA := ,
 
 include $(CURDIR)/common.mk
 
+# Provide a usable default tag for local container builds.
+ifeq ($(strip $(VERSION)),)
+VERSION := latest
+endif
+
 IMAGE_TAG := $(VERSION)
 IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
+BASE_IMAGE ?= docker.io/ubuntu:22.04
+
+# Map host CPU to a Docker platform.
+UNAME_M ?= $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+	HOST_PLATFORM := linux/amd64
+else ifeq ($(UNAME_M),arm64)
+	HOST_PLATFORM := linux/arm64
+else ifeq ($(UNAME_M),aarch64)
+	HOST_PLATFORM := linux/arm64
+else ifeq ($(UNAME_M),ppc64le)
+	HOST_PLATFORM := linux/ppc64le
+else
+	$(error Unsupported local platform: $(UNAME_M))
+endif
+
+# Default PLATFORMS to the host when unset. An explicit non-empty value overrides
+# detection; an explicit empty value is treated as an error to avoid confusing
+# Docker/buildx failures.
+ifeq ($(origin PLATFORMS), undefined)
+  PLATFORMS := $(HOST_PLATFORM)
+else ifeq ($(strip $(PLATFORMS)),)
+  $(error PLATFORMS is set but empty. Unset it to use the host platform, or provide one or more values)
+endif
+
+BUILDX_BUILDER ?= dra-example-driver-builder
+
+# Default to disabled so release builds are stable across older buildx setups.
+# Can be overridden by CI/release jobs that require attestations.
+BUILDX_PROVENANCE ?= false
+# Default to disabled to avoid extra metadata generation unless explicitly needed.
+BUILDX_SBOM ?= false
+BUILDX_METADATA_FLAGS = \
+	--provenance=$(BUILDX_PROVENANCE) \
+	--sbom=$(BUILDX_SBOM)
+
+# Shared docker build / buildx arguments (expanded at use time so target-specific
+# overrides such as BASE_IMAGE on distribution targets are respected).
+IMAGE_BUILD_ARGS = \
+	--build-arg GO_VERSION="$(GO_VERSION)" \
+	--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
+	--build-arg VERSION="$(VERSION)"
+
+IMAGE_BUILD_FLAGS = \
+	--pull \
+	--tag $(IMAGE) \
+	$(IMAGE_BUILD_ARGS) \
+	-f $(DOCKERFILE) \
+	$(CURDIR)
+
+BUILDX_BUILD_FLAGS = \
+	$(IMAGE_BUILD_FLAGS) \
+	--builder $(BUILDX_BUILDER) \
+	$(BUILDX_METADATA_FLAGS) \
+	--platform $(PLATFORMS)
 
 ##### Public rules #####
-.PHONY: $(DISTRIBUTIONS)
+.PHONY: $(DISTRIBUTIONS) build push ensure-buildx-builder
 
 ubuntu22.04: BASE_IMAGE = docker.io/ubuntu:22.04
 
 # Use a generic build target to build the relevant images
 $(DISTRIBUTIONS):
-	DOCKER_BUILDKIT=1 \
-		$(CONTAINER_TOOL) build --pull \
-		--tag $(IMAGE) \
-		--build-arg GO_VERSION="$(GO_VERSION)" \
-		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
-		--build-arg VERSION="$(VERSION)" \
-		-f $(DOCKERFILE) \
-		$(CURDIR)
+	$(MAKE) -f $(SELF_MAKEFILE) build BASE_IMAGE="$(BASE_IMAGE)"
+
+build:
+# Multi-arch builds must use buildx (docker only).
+ifneq ($(findstring $(COMMA),$(PLATFORMS)),)
+	@echo "Building image for multiple platforms with buildx: $(PLATFORMS)"
+	@if [ "$(CONTAINER_TOOL)" != "docker" ]; then \
+		echo "Multi-platform build requires CONTAINER_TOOL=docker, got $(CONTAINER_TOOL)"; \
+		exit 1; \
+	fi
+	@echo "Note: multi-platform build does not load image into local Docker daemon."
+	$(MAKE) -f $(SELF_MAKEFILE) ensure-buildx-builder
+	$(CONTAINER_TOOL) buildx build $(BUILDX_BUILD_FLAGS)
+else ifeq ($(PLATFORMS),$(HOST_PLATFORM))
+	# Native single-arch build for the host platform.
+	@echo "Building image for single platform: $(PLATFORMS)"
+	$(if $(filter docker,$(CONTAINER_TOOL)),DOCKER_BUILDKIT=1 ,)$(CONTAINER_TOOL) build --platform $(PLATFORMS) $(IMAGE_BUILD_FLAGS)
+else
+	# Cross-arch single-platform build (e.g. linux/arm64 on x86_64): use buildx --load
+	# so --platform is honoured; requires QEMU/binfmt on Linux amd64 (see README).
+	@echo "Building image for single platform: $(PLATFORMS) (host is $(HOST_PLATFORM))"
+	@if [ "$(CONTAINER_TOOL)" != "docker" ]; then \
+		echo "Cross-platform single-arch build requires CONTAINER_TOOL=docker, got $(CONTAINER_TOOL)"; \
+		exit 1; \
+	fi
+	@echo "Note: cross-platform build uses buildx and loads the image into the local Docker daemon."
+	$(MAKE) -f $(SELF_MAKEFILE) ensure-buildx-builder
+	$(CONTAINER_TOOL) buildx build $(BUILDX_BUILD_FLAGS) --load
+endif
 
 push:
+# Multi-arch pushes publish a multi-platform manifest via buildx.
+ifneq ($(findstring $(COMMA),$(PLATFORMS)),)
+	@if [ "$(CONTAINER_TOOL)" != "docker" ]; then \
+		echo "Multi-platform push requires CONTAINER_TOOL=docker, got $(CONTAINER_TOOL)"; \
+		exit 1; \
+	fi
+	@echo "Pushing image for multiple platforms with buildx: $(PLATFORMS)"
+	$(MAKE) -f $(SELF_MAKEFILE) ensure-buildx-builder
+	$(CONTAINER_TOOL) buildx build $(BUILDX_BUILD_FLAGS) --push
+else
+	# Single-arch pushes build locally first, then push the image tag.
+	$(MAKE) -f $(SELF_MAKEFILE) build
 	$(CONTAINER_TOOL) push $(IMAGE)
+endif
+
+ensure-buildx-builder:
+ifeq ($(CONTAINER_TOOL),docker)
+	@docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1 || \
+		docker buildx create --name $(BUILDX_BUILDER) --driver docker-container --use
+	@docker buildx use $(BUILDX_BUILDER)
+	@docker buildx inspect --bootstrap $(BUILDX_BUILDER) >/dev/null
+else
+	@echo "ensure-buildx-builder requires CONTAINER_TOOL=docker"
+	@exit 1
+endif


### PR DESCRIPTION
### Summary
- Add Docker Buildx-based multi-arch image publishing for the container image build flow.
- Keep local developer workflow simple by adding a `build` target that loads a single-arch image into Docker.
- Document container image make recipes in `README.md` for build, local load, and multi-arch push use cases.

Fixes #161 

### What changed
- `deployments/container/Makefile`
  - Add `PLATFORMS` (default `linux/amd64,linux/arm64`)
  - Add `BUILDX_BUILDER` and `ensure-buildx-builder` helper target
  - Add `build` target (`buildx --load`) for local image testing
  - Add `push` target (`buildx --push`) for multi-arch publishing
- `README.md`
  - Add a new "Container image make recipes" section with usage examples for:
    - `build`
    - `push`

### Why
Issue request asks for ARM64 image availability. Multi-arch publish via Buildx ensures released tags include both `linux/amd64` and `linux/arm64`, while still preserving straightforward local build/test flows.

### Validation
- Ran `build` and verified command wiring and flags.
- Ran `push` and verified Buildx builder/platform settings.
- Verified multi-arch manifest output after push includes:
  - `linux/amd64`
  - `linux/arm64`