### PR TITLE
docs: Add instructions for running the example driver on GKE  and optional ResourceQuota support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The procedure below has been tested and verified on both Linux and Mac.
 * [helm v3.7.0+](https://helm.sh/docs/intro/install/)
 * [kubectl v1.18+](https://kubernetes.io/docs/reference/kubectl/)
 
-### Demo
+### Creating a cluster and installing the example driver
+
+#### Kind
 We start by first cloning this repository and `cd`ing into it. All of the
 scripts and example Pod specs used in this demo are contained here, so take a
 moment to browse through the various files and see what's available:
@@ -240,6 +242,12 @@ metadata:
   resourceVersion: ""
 ```
 
+#### Other platforms
+This demo uses kind by default. Additional platform-specific setup and cleanup
+guides are documented in [`demo/clusters`](demo/clusters/README.md), including
+GKE instructions in [`demo/clusters/gke`](demo/clusters/gke/README.md).
+
+### Run example workloads (shared across kind and GKE)
 Next, deploy four example apps that demonstrate how `ResourceClaim`s,
 `ResourceClaimTemplate`s, and custom `GpuConfig` objects can be used to
 select and configure resources in various ways:
@@ -391,7 +399,7 @@ To run this demo:
 
 This demonstration shows the end-to-end flow of the DRA AdminAccess feature. In a production environment, drivers could use this admin access indication to provide additional privileged capabilities or information to authorized workloads.
 
-### Clean Up
+### Cleanup
 
 Once you have verified everything is running correctly, delete all of the
 example apps:
@@ -420,11 +428,15 @@ admin-access                           pod0   1/1     Terminating   0          3
 ...
 ```
 
-Finally, you can run the following to cleanup your environment and delete the
-`kind` cluster started previously:
+#### Kind
+Finally, you can run the following to clean up your environment and delete the
+kind cluster started previously:
 ```bash
 ./demo/clusters/kind/delete-cluster.sh
 ```
+
+#### Other platforms
+Use the cleanup steps documented in [`demo/clusters`](demo/clusters/README.md).
 
 ## Device Profiles
 

--- a/demo/clusters/gke/README.md
+++ b/demo/clusters/gke/README.md
@@ -10,8 +10,13 @@ install/uninstall the driver.
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/)
 - Authenticated GCP account and a selected project
 
-This flow uses the pre-built image for the kubelet plugin, so no local image
-build is required.
+This flow installs published release artifacts from `registry.k8s.io` and pins
+both the Helm chart and driver image to the same version to avoid chart/image
+skew.
+
+The steps below were validated with:
+- GKE: `v1.35.2-gke.1485000`
+- Driver/chart release: `0.2.0`
 
 To keep the walkthrough simple and close to the kind demo, use a single-node
 GKE cluster.
@@ -39,8 +44,11 @@ Supported environment variables:
 
 - `DRIVER_RELEASE_NAME` (default: `dra-example-driver`)
 - `DRIVER_NAMESPACE` (default: `dra-example-driver`)
+- `DRIVER_VERSION` (default: `0.2.0`)
+- `DRIVER_CHART_REF` (default: `oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver`)
 
-The install script enables `resourceQuota.enabled=true` for GKE.
+The install script enables `resourceQuota.enabled=true` for GKE and sets
+`image.tag` to `DRIVER_VERSION` so chart/image versions remain aligned.
 
 ## Uninstall driver
 

--- a/demo/clusters/gke/README.md
+++ b/demo/clusters/gke/README.md
@@ -1,0 +1,55 @@
+# Running the demo on GKE
+
+Use the helper scripts in this directory to create or delete a GKE cluster and
+install/uninstall the driver.
+
+## Prerequisites
+
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install)
+- [helm](https://helm.sh/docs/intro/install/)
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/)
+- Authenticated GCP account and a selected project
+
+This flow uses the pre-built image for the kubelet plugin, so no local image
+build is required.
+
+To keep the walkthrough simple and close to the kind demo, use a single-node
+GKE cluster.
+
+## Create cluster
+
+```bash
+./demo/clusters/gke/create-cluster.sh
+```
+
+Supported environment variables:
+
+- `GKE_CLUSTER_NAME` (default: `dra-example-driver-cluster`)
+- `GKE_LOCATION` (default: `us-central1-c`)
+- `GKE_RELEASE_CHANNEL` (default: `rapid`)
+- `GKE_NUM_NODES` (default: `1`)
+
+## Install driver
+
+```bash
+./demo/clusters/gke/install-driver.sh
+```
+
+Supported environment variables:
+
+- `DRIVER_RELEASE_NAME` (default: `dra-example-driver`)
+- `DRIVER_NAMESPACE` (default: `dra-example-driver`)
+
+The install script enables `resourceQuota.enabled=true` for GKE.
+
+## Uninstall driver
+
+```bash
+./demo/clusters/gke/uninstall-driver.sh
+```
+
+## Delete cluster
+
+```bash
+./demo/clusters/gke/delete-cluster.sh
+```

--- a/demo/clusters/gke/create-cluster.sh
+++ b/demo/clusters/gke/create-cluster.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+: "${GKE_CLUSTER_NAME:=dra-example-driver-cluster}"
+: "${GKE_LOCATION:=us-central1-c}"
+: "${GKE_RELEASE_CHANNEL:=rapid}"
+: "${GKE_NUM_NODES:=1}"
+
+gcloud container clusters create "${GKE_CLUSTER_NAME}" \
+  --location="${GKE_LOCATION}" \
+  --release-channel="${GKE_RELEASE_CHANNEL}" \
+  --num-nodes="${GKE_NUM_NODES}"
+
+gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --location "${GKE_LOCATION}"
+
+echo "GKE cluster creation complete: ${GKE_CLUSTER_NAME}"

--- a/demo/clusters/gke/delete-cluster.sh
+++ b/demo/clusters/gke/delete-cluster.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+: "${GKE_CLUSTER_NAME:=dra-example-driver-cluster}"
+: "${GKE_LOCATION:=us-central1-c}"
+
+gcloud container clusters delete "${GKE_CLUSTER_NAME}" \
+  --location="${GKE_LOCATION}"
+
+echo "GKE cluster deletion complete: ${GKE_CLUSTER_NAME}"

--- a/demo/clusters/gke/install-driver.sh
+++ b/demo/clusters/gke/install-driver.sh
@@ -16,17 +16,18 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
-
 : "${DRIVER_RELEASE_NAME:=dra-example-driver}"
 : "${DRIVER_NAMESPACE:=dra-example-driver}"
+: "${DRIVER_VERSION:=0.2.0}"
+: "${DRIVER_CHART_REF:=oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver}"
 
 helm upgrade -i \
   --create-namespace \
   --namespace "${DRIVER_NAMESPACE}" \
+  --version "${DRIVER_VERSION}" \
   --set resourceQuota.enabled=true \
+  --set image.tag="${DRIVER_VERSION}" \
   "${DRIVER_RELEASE_NAME}" \
-  "${REPO_ROOT}/deployments/helm/dra-example-driver"
+  "${DRIVER_CHART_REF}"
 
-echo "Driver install/upgrade complete: ${DRIVER_RELEASE_NAME} (${DRIVER_NAMESPACE})"
+echo "Driver install/upgrade complete: ${DRIVER_RELEASE_NAME} (${DRIVER_NAMESPACE}), version ${DRIVER_VERSION}"

--- a/demo/clusters/gke/install-driver.sh
+++ b/demo/clusters/gke/install-driver.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../" && pwd)"
+
+: "${DRIVER_RELEASE_NAME:=dra-example-driver}"
+: "${DRIVER_NAMESPACE:=dra-example-driver}"
+
+helm upgrade -i \
+  --create-namespace \
+  --namespace "${DRIVER_NAMESPACE}" \
+  --set resourceQuota.enabled=true \
+  "${DRIVER_RELEASE_NAME}" \
+  "${REPO_ROOT}/deployments/helm/dra-example-driver"
+
+echo "Driver install/upgrade complete: ${DRIVER_RELEASE_NAME} (${DRIVER_NAMESPACE})"

--- a/demo/clusters/gke/uninstall-driver.sh
+++ b/demo/clusters/gke/uninstall-driver.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+: "${DRIVER_RELEASE_NAME:=dra-example-driver}"
+: "${DRIVER_NAMESPACE:=dra-example-driver}"
+
+helm uninstall "${DRIVER_RELEASE_NAME}" --namespace "${DRIVER_NAMESPACE}"
+
+echo "Driver uninstall complete: ${DRIVER_RELEASE_NAME} (${DRIVER_NAMESPACE})"

--- a/deployments/helm/dra-example-driver/templates/resourcequota.yaml
+++ b/deployments/helm/dra-example-driver/templates/resourcequota.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.resourceQuota.enabled }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-resourcequota
+  namespace: {{ include "dra-example-driver.namespace" . }}
+spec:
+  hard:
+    pods: {{ .Values.resourceQuota.pods }}
+  {{- with .Values.resourceQuota.scopeSelector.matchExpressions }}
+  scopeSelector:
+    matchExpressions:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -90,3 +90,14 @@ webhook:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+
+resourceQuota:
+  enabled: false
+  pods: 10
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+      - system-cluster-critical


### PR DESCRIPTION
## Summary
This PR revives and updates the GKE documentation work from #93.

- Add a dedicated README section for installing `dra-example-driver` on GKE
- Add Helm chart support for optional `ResourceQuota` creation:
  - `resourcequota.enabled`
  - `resourcequota.pods`
  - `resourcequota.scopeSelector.matchExpressions`
- Add `templates/resourcequota.yaml` to render the ResourceQuota when enabled
- Incorporate prior review feedback

Fixes part of #94 
Supersedes: #93

## Why
GKE users need slightly different setup steps than kind, especially around running pods with critical priority classes.  
This PR documents the GKE flow and provides a chart toggle to create the required quota policy cleanly.

## Changes
- `README.md`
  - Added `Installing the example driver on a GKE cluster`
  - Added note about avoiding chart/image skew by using matching source revisions
- `deployments/helm/dra-example-driver/values.yaml`
  - Added `resourcequota` configuration block
- `deployments/helm/dra-example-driver/templates/resourcequota.yaml`
  - New template, conditional on `.Values.resourcequota.enabled`

## Test Plan

Validated on GKE cluster (`v1.35.2-gke.1485000`).

- Lint and render chart in both modes:
  - `helm lint deployments/helm/dra-example-driver`
  - `helm lint deployments/helm/dra-example-driver --set resourcequota.enabled=true`
  - `helm template ... --namespace dra-example-driver` (with and without `resourcequota.enabled=true`)
- Install with ResourceQuota enabled:
  - `helm upgrade -i --create-namespace --namespace dra-example-driver --set resourcequota.enabled=true dra-example-driver ./deployments/helm/dra-example-driver`
- Verify ResourceQuota exists and is active:
  - `kubectl get resourcequota -n dra-example-driver`
  - observed: `dra-example-driver-resourcequota` with pod quota usage (`pods: 1/10`)
- Apply demo workloads:
  - `kubectl apply --filename=demo/gpu-test{1,2,3,4,5}.yaml`
- Verify workloads and driver are running:
  - `kubectl get pods -A`
- Verify allocation semantics in logs:
  - checked GPU env vars from demo pods/containers
  - observed expected `TimeSlicing` / `SpacePartitioning` behavior
- Toggle ResourceQuota off and verify removal:
  - `helm upgrade -i --namespace dra-example-driver --set resourcequota.enabled=false dra-example-driver ./deployments/helm/dra-example-driver`
  - `kubectl get resourcequota -n dra-example-driver`
  - observed: `No resources found in dra-example-driver namespace.`

## Notes
- Scope is intentionally limited to docs + Helm chart support needed by the GKE install flow.
- Broader README restructuring discussed in #93/#94 can be handled separately.