### PR TITLE
Add option to run e2e tests against the official helm chart and container image in registry.k8s.io

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,11 +41,13 @@ The process for both is as follows:
    SHA digests and tags of the new artifacts from the staging repo.
     - Example PR: https://github.com/kubernetes/k8s.io/pull/7871
     - After the PR merges, a run of the [promotion job] will kick off.
-1. The artifacts are verified to be available from registry.k8s.io:
-    - e.g. the v0.2.0 image and 0.2.0 chart can be verified with the following
-      commands:
-        - `docker manifest inspect registry.k8s.io/dra-example-driver/dra-example-driver:v0.2.0`
-        - `docker manifest inspect registry.k8s.io/dra-example-driver/charts/dra-example-driver:0.2.0`
+1. The artifacts are verified to be available from registry.k8s.io and validated through e2e tests:
+   - e.g. the v0.2.0 image and 0.2.0 chart can be verified with the following
+     commands:
+     - `docker manifest inspect registry.k8s.io/dra-example-driver/dra-example-driver:v0.2.0`
+     - `docker manifest inspect registry.k8s.io/dra-example-driver/charts/dra-example-driver:0.2.0`
+   - Run the e2e tests against the latest release artifacts by setting `HELM_CHART_PATH` to the registry path:
+     - `HELM_CHART_PATH="oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver" make setup-e2e test-e2e teardown-e2e`
 1. The drafted [GitHub release][releases] is published.
 1. The release issue is closed.
 1. An announcement is made to [#wg-device-management] on Slack.

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -17,7 +17,14 @@
 # stop at first failure to save time
 set -e
 
-bash demo/build-driver.sh
+# Use local Helm chart by default, or from OCI registry if HELM_CHART_PATH is set
+# Example: HELM_CHART_PATH="oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver" make setup-e2e
+HELM_CHART_PATH="${HELM_CHART_PATH:-deployments/helm/dra-example-driver}"
+
+# Skip building local driver image if using OCI registry chart
+if [[ "${HELM_CHART_PATH}" != oci://* ]]; then
+	bash demo/build-driver.sh
+fi
 bash demo/create-cluster.sh
 
 helm upgrade -i \
@@ -36,4 +43,4 @@ helm upgrade -i \
   --set webhook.enabled=true \
   --set kubeletPlugin.numDevices=10 \
   dra-example-driver \
-  deployments/helm/dra-example-driver
+  ${HELM_CHART_PATH}


### PR DESCRIPTION
Fixes #122 

Currently the e2e tests are run against the local builds, this PR adds an option to run the e2e tests against the officially published helm chart and container images in the registry.k8s.io by adding an environment variable HELM_CHART_PATH.

To use officially published charts from registry, provide the registry path as below and invoke "make setup-e2e".
Example: `HELM_CHART_PATH="oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver" make setup-e2e`

The default value for HELM_CHART_PATH is `deployments/helm/dra-example-driver` which is used for local builds