### PR TITLE
Improve E2E test isolation, error reporting, and extensibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ setup-e2e:
 	test/e2e/setup-e2e.sh
 
 test-e2e:
-	go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e ./test/e2e/...
+	go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -p ./test/e2e/...
 
 teardown-e2e:
 	test/e2e/teardown-e2e.sh

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -27,13 +27,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,6 +51,9 @@ var clientset *kubernetes.Clientset
 var dynamicClient dynamic.Interface
 var restMapper meta.RESTMapper
 
+const driverNamespace = "dra-example-driver"
+const driverPodSelector = "app.kubernetes.io/component=kubeletplugin"
+
 func init() {
 	currentDir, _ = os.Getwd()
 	rootDir = filepath.Join(filepath.Dir(currentDir), "..")
@@ -62,6 +66,11 @@ const (
 	checkPodLogsInterval = "1s"
 )
 
+var (
+	gpuDeviceRegexp = regexp.MustCompile(`(?m)^declare -x GPU_DEVICE_[0-9]+="(.+)"$`)
+	gpuIDRegexp     = regexp.MustCompile(`^gpu-([0-9]+)$`)
+)
+
 func TestE2e(t *testing.T) {
 	flag.Parse()
 	RegisterFailHandler(Fail)
@@ -69,11 +78,6 @@ func TestE2e(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(ctx SpecContext) {
-	suiteConfig, _ := GinkgoConfiguration()
-	if suiteConfig.ParallelTotal > 1 {
-		Fail("tests cannot be run in parallel")
-	}
-
 	// Create a Kubernetes clientset
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
@@ -138,13 +142,75 @@ func verifyWebhook(ctx context.Context) {
 	}, "30s", "1s").WithContext(ctx).Should(Succeed())
 }
 
-// deployManifest creates resources from a manifest file and returns a cleanup function.
-func deployManifest(ctx context.Context, manifestFile string) func() {
+// deployManifest creates resources from a manifest file and registers cleanup
+// and failure diagnostics via DeferCleanup.
+func deployManifest(ctx context.Context, namespace string, manifestFile string) {
 	GinkgoHelper()
 	absPath := filepath.Join(demoManifestsDir, manifestFile)
 	createManifest(ctx, dynamicClient, absPath)
-	return func() {
-		deleteManifest(context.Background(), dynamicClient, absPath)
+	// DeferCleanup is LIFO: register cleanup first, then diagnostics second.
+	// On teardown, diagnostics run first (while pods exist), then cleanup deletes them.
+	DeferCleanup(func(ctx context.Context) {
+		deleteManifest(ctx, dynamicClient, absPath)
+	}, NodeTimeout(30*time.Second))
+	DeferCleanup(dumpDiagnosticsOnFailure, namespace, NodeTimeout(15*time.Second))
+}
+
+// dumpDiagnosticsOnFailure collects pod status, events, and driver logs
+// when a test has failed. Intended for use as a DeferCleanup callback.
+func dumpDiagnosticsOnFailure(ctx context.Context, namespace string) {
+	if !CurrentSpecReport().Failed() {
+		return
+	}
+
+	fmt.Fprintf(GinkgoWriter, "\n=== Failure diagnostics for namespace %s ===\n", namespace)
+
+	// Pod status
+	podList, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to list pods: %v\n", err)
+	} else {
+		for _, pod := range podList.Items {
+			fmt.Fprintf(GinkgoWriter, "Pod %s: phase=%s conditions=%v\n",
+				pod.Name, pod.Status.Phase, pod.Status.Conditions)
+		}
+	}
+
+	// Events
+	events, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to list events: %v\n", err)
+	} else {
+		for _, e := range events.Items {
+			fmt.Fprintf(GinkgoWriter, "Event %s/%s: %s %s\n",
+				e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Message)
+		}
+	}
+
+	// Driver logs
+	tailLines := int64(20)
+	driverPods, err := clientset.CoreV1().Pods(driverNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: driverPodSelector,
+	})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "Failed to list driver pods: %v\n", err)
+		return
+	}
+	for _, pod := range driverPods.Items {
+		for _, c := range pod.Spec.Containers {
+			stream, err := clientset.CoreV1().Pods(driverNamespace).GetLogs(pod.Name, &v1.PodLogOptions{
+				Container: c.Name,
+				TailLines: &tailLines,
+			}).Stream(ctx)
+			if err != nil {
+				fmt.Fprintf(GinkgoWriter, "Driver pod %s, container %s: failed to get logs: %v\n", pod.Name, c.Name, err)
+				continue
+			}
+			buf := new(bytes.Buffer)
+			io.Copy(buf, stream)
+			stream.Close()
+			fmt.Fprintf(GinkgoWriter, "Driver pod %s, container %s (last %d lines):\n%s\n", pod.Name, c.Name, tailLines, buf.String())
+		}
 	}
 }
 
@@ -186,13 +252,13 @@ func parseManifests(manifestPath string) ([]*unstructured.Unstructured, error) {
 // getGVRForObject returns the GroupVersionResource for an unstructured object
 func getGVRForObject(obj *unstructured.Unstructured) (schema.GroupVersionResource, error) {
 	gvk := obj.GroupVersionKind()
-	
+
 	// Use RESTMapper to get the correct resource name
 	mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return schema.GroupVersionResource{}, fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)
 	}
-	
+
 	return mapping.Resource, nil
 }
 
@@ -204,7 +270,7 @@ func createObjects(ctx context.Context, dynamicClient dynamic.Interface, objects
 		if err != nil {
 			return fmt.Errorf("failed to get GVR for object %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 		}
-		
+
 		namespace := obj.GetNamespace()
 
 		createOptions := metav1.CreateOptions{}
@@ -229,6 +295,7 @@ func createObjects(ctx context.Context, dynamicClient dynamic.Interface, objects
 }
 
 // deleteObjects deletes a list of unstructured objects using the dynamic client
+// and waits for them to be fully removed.
 func deleteObjects(ctx context.Context, dynamicClient dynamic.Interface, objects []*unstructured.Unstructured) {
 	GinkgoHelper()
 	deletePolicy := metav1.DeletePropagationForeground
@@ -243,7 +310,7 @@ func deleteObjects(ctx context.Context, dynamicClient dynamic.Interface, objects
 				obj.GetNamespace(), obj.GetName(), err)
 			continue
 		}
-		
+
 		namespace := obj.GetNamespace()
 		gvk := obj.GroupVersionKind()
 
@@ -253,11 +320,34 @@ func deleteObjects(ctx context.Context, dynamicClient dynamic.Interface, objects
 			err = dynamicClient.Resource(gvr).Delete(ctx, obj.GetName(), deleteOptions)
 		}
 
-		// Ignore not found errors
-		if err != nil && !strings.Contains(err.Error(), "not found") {
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Warning: Failed to delete %s/%s in namespace %s: %v\n",
 				gvk.Kind, obj.GetName(), namespace, err)
 		}
+	}
+
+	// Wait for all objects to be fully removed
+	for _, obj := range objects {
+		gvr, err := getGVRForObject(obj)
+		if err != nil {
+			continue
+		}
+		namespace := obj.GetNamespace()
+		name := obj.GetName()
+
+		Eventually(func() bool {
+			var err error
+			if namespace != "" {
+				_, err = dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			} else {
+				_, err = dynamicClient.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+			}
+			return apierrors.IsNotFound(err)
+		}).WithContext(ctx).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(BeTrue(),
+			"Timed out waiting for %s/%s to be deleted", obj.GroupVersionKind().Kind, name)
 	}
 }
 
@@ -293,54 +383,50 @@ func createManifestWithDryRun(ctx context.Context, dynamicClient dynamic.Interfa
 	return createObjects(ctx, dynamicClient, objects, true)
 }
 
-func checkPodsReadyAndRunning(namespace string, pods []string, expectedPodCount int) {
+func checkPodsReadyAndRunning(ctx context.Context, namespace string, pods []string) {
 	GinkgoHelper()
+	// check if the pods are Ready and Running
 	for _, podName := range pods {
 		Eventually(func(g Gomega) {
-			pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-			g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s/%s", namespace, podName)
+			pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred(),
+				"Failed to get pod %s/%s", namespace, podName)
+			g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning),
+				"Pod %s/%s has phase %s, expected Running (conditions: %v)",
+				namespace, podName, pod.Status.Phase, pod.Status.Conditions)
 			ready := false
 			for _, cond := range pod.Status.Conditions {
-				if cond.Type == "Ready" && cond.Status == "True" {
+				if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
 					ready = true
 					break
 				}
 			}
 			g.Expect(ready).To(BeTrue(),
-				"Pod %s/%s is not Ready (phase: %s, conditions: %v)",
-				namespace, podName, pod.Status.Phase, pod.Status.Conditions)
+				"Pod %s/%s is Running but not Ready (conditions: %v)",
+				namespace, podName, pod.Status.Conditions)
 		}, "120s", "5s").Should(Succeed())
 	}
-	// check if the pods are in Running state
-	podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	runningPodCount := 0
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == "Running" {
-			runningPodCount++
-		}
-	}
-	Expect(runningPodCount).To(Equal(expectedPodCount),
-		"Expected %d running pods in namespace %s, got %d", expectedPodCount, namespace, runningPodCount)
 }
 
-// getGPUsFromPodLogs retrieves pod logs and extracts GPU device information
-func getGPUsFromPodLogs(namespace, pod, container string) ([]string, string) {
+// getGPUsFromPodLogs retrieves pod logs and extracts GPU device information.
+// Returns errors via g so callers inside Eventually can retry on transient failures.
+func getGPUsFromPodLogs(ctx context.Context, g Gomega, namespace, pod, container string) ([]string, string) {
 	GinkgoHelper()
 	req := clientset.CoreV1().Pods(namespace).GetLogs(pod, &v1.PodLogOptions{
 		Container: container,
 	})
-	podLogs, err := req.Stream(context.TODO())
-	Expect(err).NotTo(HaveOccurred())
+	podLogs, err := req.Stream(ctx)
+	g.Expect(err).NotTo(HaveOccurred(),
+		"Failed to stream logs for pod %s/%s, container %s", namespace, pod, container)
 	defer podLogs.Close()
 
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)
-	Expect(err).NotTo(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred(),
+		"Failed to read logs for pod %s/%s, container %s", namespace, pod, container)
 	logs := buf.String()
 
-	re := regexp.MustCompile(`(?m)^declare -x GPU_DEVICE_[0-9]+="(.+)"$`)
-	matches := re.FindAllStringSubmatch(logs, -1)
+	matches := gpuDeviceRegexp.FindAllStringSubmatch(logs, -1)
 
 	var gpus []string
 	for _, m := range matches {
@@ -349,11 +435,6 @@ func getGPUsFromPodLogs(namespace, pod, container string) ([]string, string) {
 		}
 	}
 	return gpus, logs
-}
-
-func isGPUAlreadySeen(observedGPUs map[string]string, gpu string) bool {
-	_, alreadySeen := observedGPUs[gpu]
-	return alreadySeen
 }
 
 func extractGPUProperty(logs string, id string, property string) string {
@@ -373,8 +454,7 @@ func extractGPUProperty(logs string, id string, property string) string {
 }
 
 func getGPUID(gpu string) string {
-	re := regexp.MustCompile(`^gpu-([0-9]+)$`)
-	matches := re.FindAllStringSubmatch(gpu, -1)
+	matches := gpuIDRegexp.FindAllStringSubmatch(gpu, -1)
 	if len(matches) > 0 && len(matches[0]) > 1 {
 		return matches[0][1]
 	}
@@ -383,12 +463,11 @@ func getGPUID(gpu string) string {
 
 // verifyGPUAllocation checks that a pod/container has the expected number of GPUs
 // and tracks them in observedGPUs to ensure no GPU is claimed twice within a test
-func verifyGPUAllocation(namespace, podName, containerName string, expectedGPUCount int, observedGPUs map[string]string) {
+func verifyGPUAllocation(ctx context.Context, namespace, podName, containerName string, expectedGPUCount int, observedGPUs map[string]string) {
 	GinkgoHelper()
-	var gpus []string
 	Eventually(func(g Gomega) {
 		// Get pod logs and extract GPUs
-		gpus, _ = getGPUsFromPodLogs(namespace, podName, containerName)
+		gpus, _ := getGPUsFromPodLogs(ctx, g, namespace, podName, containerName)
 		verifyGPUCount(g, gpus, expectedGPUCount, namespace, podName, containerName)
 
 		// Verify each GPU is unclaimed
@@ -399,26 +478,29 @@ func verifyGPUAllocation(namespace, podName, containerName string, expectedGPUCo
 }
 
 // verifyDRAAdminAccess verifies that DRA_ADMIN_ACCESS is set to the expected value
-func verifyDRAAdminAccess(namespace, podName, containerName, expectedValue string) {
+func verifyDRAAdminAccess(ctx context.Context, namespace, podName, containerName, expectedValue string) {
 	GinkgoHelper()
 	Eventually(func(g Gomega) {
-		_, logs := getGPUsFromPodLogs(namespace, podName, containerName)
+		_, logs := getGPUsFromPodLogs(ctx, g, namespace, podName, containerName)
 		draAdminAccess := extractGPUProperty(logs, "", "DRA_ADMIN_ACCESS")
 		g.Expect(draAdminAccess).To(Equal(expectedValue),
 			fmt.Sprintf("Expected Pod %s/%s, container %s to have DRA_ADMIN_ACCESS=%s, but got %s",
 				namespace, podName, containerName, expectedValue, draAdminAccess))
-		fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s has DRA_ADMIN_ACCESS=%s\n", namespace, podName, containerName, draAdminAccess)
+		fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s has DRA_ADMIN_ACCESS=%s\n",
+			namespace, podName, containerName, draAdminAccess)
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 }
 
 // claimNewGPU verifies that a GPU is unclaimed and adds it to observedGPUs
 func claimNewGPU(g Gomega, observedGPUs map[string]string, gpu, namespace, podName, containerName string) {
 	GinkgoHelper()
-	g.Expect(isGPUAlreadySeen(observedGPUs, gpu)).To(Equal(false),
+	claimedBy, alreadySeen := observedGPUs[gpu]
+	g.Expect(alreadySeen).To(BeFalse(),
 		fmt.Sprintf("Pod %s/%s, container %s should have a new GPU but claimed %s which is already claimed by %s",
-			namespace, podName, containerName, gpu, observedGPUs[gpu]))
+			namespace, podName, containerName, gpu, claimedBy))
 	observedGPUs[gpu] = namespace + "/" + podName
-	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s\n", namespace, podName, containerName, gpu)
+	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s\n",
+		namespace, podName, containerName, gpu)
 }
 
 // verifyGPUCount verifies that a container has the expected number of GPUs
@@ -427,15 +509,6 @@ func verifyGPUCount(g Gomega, gpus []string, expectedGPUCount int, namespace, po
 	g.Expect(gpus).To(HaveLen(expectedGPUCount),
 		fmt.Sprintf("Expected Pod %s/%s, container %s to have %d GPUs, but got %d: %v",
 			namespace, podName, containerName, expectedGPUCount, len(gpus), gpus))
-}
-
-// verifySharedGPU verifies that a container reuses the same GPU as expected
-func verifySharedGPU(g Gomega, gpu, expectedGPU, namespace, podName, containerName string) {
-	GinkgoHelper()
-	g.Expect(gpu).To(Equal(expectedGPU),
-		fmt.Sprintf("Pod %s/%s, container %s should claim the same GPU as previous, but got %s instead of %s",
-			namespace, podName, containerName, gpu, expectedGPU))
-	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s\n", namespace, podName, containerName, gpu)
 }
 
 // verifyGPUProperties verifies GPU sharing strategy and an optional additional property
@@ -451,5 +524,50 @@ func verifyGPUProperties(g Gomega, logs, namespace, podName, containerName strin
 		g.Expect(propertyValue).To(Equal(expectedPropertyValue),
 			fmt.Sprintf("Expected Pod %s/%s, container %s to have %s=%s, got %s",
 				namespace, podName, containerName, expectedProperty, expectedPropertyValue, propertyValue))
+	}
+}
+
+// podContainer identifies a specific container in a specific pod.
+type podContainer struct {
+	pod       string
+	container string
+}
+
+// sharingGroup describes a set of pod/containers that should all share the same GPU,
+// along with the expected sharing properties.
+type sharingGroup struct {
+	// members lists the pod/container pairs that should all see the same GPU.
+	members []podContainer
+	// expectedStrategy is the expected GPU sharing strategy (e.g. "TimeSlicing", "SpacePartitioning").
+	expectedStrategy string
+	// expectedProperty is the name of the GPU property to verify (e.g. "TIMESLICE_INTERVAL", "PARTITION_COUNT").
+	expectedProperty string
+	// expectedPropValue is the expected value of expectedProperty (e.g. "Default", "Long", "10").
+	expectedPropValue string
+}
+
+// verifySharedGPUGroup verifies that all members of a sharing group see the same GPU
+// and that the GPU has the expected sharing properties.
+func verifySharedGPUGroup(ctx context.Context, namespace string, group sharingGroup) {
+	GinkgoHelper()
+	var firstGPU string
+	for i, member := range group.members {
+		Eventually(func(g Gomega) {
+			gpus, logs := getGPUsFromPodLogs(ctx, g, namespace, member.pod, member.container)
+			verifyGPUCount(g, gpus, 1, namespace, member.pod, member.container)
+			if i == 0 {
+				firstGPU = gpus[0]
+				fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s has GPU %s (first in group)\n",
+					namespace, member.pod, member.container, firstGPU)
+			} else {
+				g.Expect(gpus[0]).To(Equal(firstGPU),
+					fmt.Sprintf("Pod %s/%s, container %s should claim the same GPU as previous, but got %s instead of %s",
+						namespace, member.pod, member.container, gpus[0], firstGPU))
+				fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s shares GPU %s\n",
+					namespace, member.pod, member.container, gpus[0])
+			}
+			verifyGPUProperties(g, logs, namespace, member.pod, member.container, gpus,
+				group.expectedStrategy, group.expectedProperty, group.expectedPropValue)
+		}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 	}
 }

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -46,17 +46,6 @@ import (
 )
 
 var rootDir, currentDir, demoManifestsDir string
-var observedGPUs map[string]string
-var demoFiles = []string{
-	"basic-resourceclaimtemplate.yaml",
-	"basic-multiple-requests.yaml",
-	"basic-shared-claim-across-containers.yaml",
-	"admin-access.yaml", // deploying this earlier to ensure the pod can access in-use devices and does not block future allocations of the same devices
-	"basic-shared-claim-across-pods.yaml",
-	"basic-resourceclaim-opaque-config.yaml",
-	"initcontainer-shared-gpu.yaml",
-	"cel-selector.yaml",
-}
 var clientset *kubernetes.Clientset
 var dynamicClient dynamic.Interface
 var restMapper meta.RESTMapper
@@ -64,7 +53,6 @@ var restMapper meta.RESTMapper
 func init() {
 	currentDir, _ = os.Getwd()
 	rootDir = filepath.Join(filepath.Dir(currentDir), "..")
-	observedGPUs = make(map[string]string)
 	// command line flag for demo manifests directory
 	flag.StringVar(&demoManifestsDir, "demo-manifests-dir", filepath.Join(rootDir, "demo"), "Directory containing demo YAML manifests")
 }
@@ -110,13 +98,6 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	// issues, so retry here until we can ensure it's available before the real tests start.
 	By("Ensuring the webhook is ready")
 	verifyWebhook(ctx)
-
-	// Deploy all the test files
-	By("Deploying all the GPU test files")
-	for _, file := range demoFiles {
-		absPath := filepath.Join(demoManifestsDir, file)
-		createManifest(ctx, dynamicClient, absPath)
-	}
 })
 
 func verifyWebhook(ctx context.Context) {
@@ -155,6 +136,16 @@ func verifyWebhook(ctx context.Context) {
 		}
 		return nil
 	}, "30s", "1s").WithContext(ctx).Should(Succeed())
+}
+
+// deployManifest creates resources from a manifest file and returns a cleanup function.
+func deployManifest(ctx context.Context, manifestFile string) func() {
+	GinkgoHelper()
+	absPath := filepath.Join(demoManifestsDir, manifestFile)
+	createManifest(ctx, dynamicClient, absPath)
+	return func() {
+		deleteManifest(context.Background(), dynamicClient, absPath)
+	}
 }
 
 // parseManifests reads a YAML file and returns a slice of unstructured objects
@@ -304,20 +295,21 @@ func createManifestWithDryRun(ctx context.Context, dynamicClient dynamic.Interfa
 
 func checkPodsReadyAndRunning(namespace string, pods []string, expectedPodCount int) {
 	GinkgoHelper()
-	// check if the pods are Ready
 	for _, podName := range pods {
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
+			g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s/%s", namespace, podName)
+			ready := false
 			for _, cond := range pod.Status.Conditions {
 				if cond.Type == "Ready" && cond.Status == "True" {
-					return true
+					ready = true
+					break
 				}
 			}
-			return false
-		}, "120s", "5s").Should(BeTrue())
+			g.Expect(ready).To(BeTrue(),
+				"Pod %s/%s is not Ready (phase: %s, conditions: %v)",
+				namespace, podName, pod.Status.Phase, pod.Status.Conditions)
+		}, "120s", "5s").Should(Succeed())
 	}
 	// check if the pods are in Running state
 	podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
@@ -328,7 +320,8 @@ func checkPodsReadyAndRunning(namespace string, pods []string, expectedPodCount 
 			runningPodCount++
 		}
 	}
-	Expect(runningPodCount).To(Equal(expectedPodCount))
+	Expect(runningPodCount).To(Equal(expectedPodCount),
+		"Expected %d running pods in namespace %s, got %d", expectedPodCount, namespace, runningPodCount)
 }
 
 // getGPUsFromPodLogs retrieves pod logs and extracts GPU device information
@@ -358,11 +351,9 @@ func getGPUsFromPodLogs(namespace, pod, container string) ([]string, string) {
 	return gpus, logs
 }
 
-func isGPUAlreadySeen(gpu string) bool {
-	if _, alreadySeen := observedGPUs[gpu]; alreadySeen {
-		return true
-	}
-	return false
+func isGPUAlreadySeen(observedGPUs map[string]string, gpu string) bool {
+	_, alreadySeen := observedGPUs[gpu]
+	return alreadySeen
 }
 
 func extractGPUProperty(logs string, id string, property string) string {
@@ -391,8 +382,8 @@ func getGPUID(gpu string) string {
 }
 
 // verifyGPUAllocation checks that a pod/container has the expected number of GPUs
-// and tracks them in observedGPUs to ensure no GPU is claimed twice
-func verifyGPUAllocation(namespace, podName, containerName string, expectedGPUCount int) {
+// and tracks them in observedGPUs to ensure no GPU is claimed twice within a test
+func verifyGPUAllocation(namespace, podName, containerName string, expectedGPUCount int, observedGPUs map[string]string) {
 	GinkgoHelper()
 	var gpus []string
 	Eventually(func(g Gomega) {
@@ -402,7 +393,7 @@ func verifyGPUAllocation(namespace, podName, containerName string, expectedGPUCo
 
 		// Verify each GPU is unclaimed
 		for _, gpu := range gpus {
-			claimNewGPU(g, gpu, namespace, podName, containerName)
+			claimNewGPU(g, observedGPUs, gpu, namespace, podName, containerName)
 		}
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 }
@@ -421,13 +412,13 @@ func verifyDRAAdminAccess(namespace, podName, containerName, expectedValue strin
 }
 
 // claimNewGPU verifies that a GPU is unclaimed and adds it to observedGPUs
-func claimNewGPU(g Gomega, gpu, namespace, podName, containerName string) {
+func claimNewGPU(g Gomega, observedGPUs map[string]string, gpu, namespace, podName, containerName string) {
 	GinkgoHelper()
-	g.Expect(isGPUAlreadySeen(gpu)).To(Equal(false),
-		fmt.Sprintf("Pod %s/%s, container %s should have a new GPU but claimed %s which is already claimed",
-			namespace, podName, containerName, gpu))
+	g.Expect(isGPUAlreadySeen(observedGPUs, gpu)).To(Equal(false),
+		fmt.Sprintf("Pod %s/%s, container %s should have a new GPU but claimed %s which is already claimed by %s",
+			namespace, podName, containerName, gpu, observedGPUs[gpu]))
 	observedGPUs[gpu] = namespace + "/" + podName
-	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s", namespace, podName, containerName, gpu)
+	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s\n", namespace, podName, containerName, gpu)
 }
 
 // verifyGPUCount verifies that a container has the expected number of GPUs
@@ -442,9 +433,9 @@ func verifyGPUCount(g Gomega, gpus []string, expectedGPUCount int, namespace, po
 func verifySharedGPU(g Gomega, gpu, expectedGPU, namespace, podName, containerName string) {
 	GinkgoHelper()
 	g.Expect(gpu).To(Equal(expectedGPU),
-		fmt.Sprintf("Pod %s/%s, container %s should claim the same GPU as %s, but did not",
-			namespace, podName, containerName, observedGPUs[expectedGPU]))
-	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s", namespace, podName, containerName, gpu)
+		fmt.Sprintf("Pod %s/%s, container %s should claim the same GPU as previous, but got %s instead of %s",
+			namespace, podName, containerName, gpu, expectedGPU))
+	fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s claimed %s\n", namespace, podName, containerName, gpu)
 }
 
 // verifyGPUProperties verifies GPU sharing strategy and an optional additional property
@@ -462,15 +453,3 @@ func verifyGPUProperties(g Gomega, logs, namespace, podName, containerName strin
 				namespace, podName, containerName, expectedProperty, expectedPropertyValue, propertyValue))
 	}
 }
-
-var _ = AfterSuite(func(ctx SpecContext) {
-	// Pod deletion should be fast (less than the default grace period of 30s)
-	// see https://github.com/kubernetes/kubernetes/issues/127188 for details
-	for _, file := range demoFiles {
-		absPath := filepath.Join(demoManifestsDir, file)
-		Eventually(func() error {
-			deleteManifest(ctx, dynamicClient, absPath)
-			return nil
-		}, "25s", "1s").Should(Succeed(), fmt.Sprintf("Failed to delete resources in %s within 25s", file))
-	}
-})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,219 +29,276 @@ import (
 
 var _ = Describe("Test GPU allocation", func() {
 	Context("Two pods, one container each, one GPU per container", func() {
-		namespace := "basic-resourceclaimtemplate"
-		pods := []string{"pod0", "pod1"}
-		containerName := "ctr0"
-		expectedGPUCount := 1
-
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "basic-resourceclaimtemplate.yaml")
 		})
-		It("should have exactly 1 unclaimed GPU per container", func() {
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should allocate 1 distinct GPU per pod", func() {
+			namespace := "basic-resourceclaimtemplate"
+			pods := []string{"pod0", "pod1"}
+			containerName := "ctr0"
+			expectedGPUCount := 1
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
 			for _, podName := range pods {
-				verifyGPUAllocation(namespace, podName, containerName, expectedGPUCount)
+				verifyGPUAllocation(namespace, podName, containerName, expectedGPUCount, observedGPUs)
 			}
 		})
 	})
-	Context("One pod, one container with two GPUs", func() {
-		namespace := "basic-multiple-requests"
-		pods := []string{"pod0"}
-		containerName := "ctr0"
-		expectedGPUCount := 2
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("One pod, one container with two GPUs", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "basic-multiple-requests.yaml")
 		})
-		It("should have exactly 2 unclaimed GPUs", func() {
-			verifyGPUAllocation(namespace, pods[0], containerName, expectedGPUCount)
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should allocate 2 distinct GPUs to a single container", func() {
+			namespace := "basic-multiple-requests"
+			pods := []string{"pod0"}
+			containerName := "ctr0"
+			expectedGPUCount := 2
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
+			verifyGPUAllocation(namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 		})
 	})
-	Context("One pod, two containers sharing one GPU with TimeSlicing and Default interval", func() {
-		namespace := "basic-shared-claim-across-containers"
-		pods := []string{"pod0"}
-		containerNames := []string{"ctr0", "ctr1"}
-		expectedGPUCount := 1
-		expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-		expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("One pod, two containers sharing one GPU with TimeSlicing and Default interval", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "basic-shared-claim-across-containers.yaml")
 		})
-		It("should have 1 GPU shared in time with default timeslice interval for each container", func() {
-			var gpus []string
-			var logs string
-			var gpuCtr0, gpuCtr1 string
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should share 1 GPU between containers with default timeslice interval", func() {
+			namespace := "basic-shared-claim-across-containers"
+			pods := []string{"pod0"}
+			containerNames := []string{"ctr0", "ctr1"}
+			expectedGPUCount := 1
+			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
+			expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
+
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
+			var gpuCtr0 string
 			for _, containerName := range containerNames {
 				Eventually(func(g Gomega) {
 					By("checking that there is exactly 1 GPU")
-					gpus, logs = getGPUsFromPodLogs(namespace, pods[0], containerName)
+					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
 					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
 					if containerName == "ctr0" {
 						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
 						gpuCtr0 = gpus[0]
-						claimNewGPU(g, gpus[0], namespace, pods[0], containerName)
+						claimNewGPU(g, observedGPUs, gpus[0], namespace, pods[0], containerName)
 					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU as of previous", containerName))
-						gpuCtr1 = gpus[0]
-						verifySharedGPU(g, gpuCtr1, gpuCtr0, namespace, pods[0], containerName)
+						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
+						verifySharedGPU(g, gpus[0], gpuCtr0, namespace, pods[0], containerName)
 					}
 					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
 				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 			}
 		})
 	})
-	Context("Two pods sharing a global ResourceClaim with TimeSlicing and Default interval", func() {
-		namespace := "basic-shared-claim-across-pods"
-		pods := []string{"pod0", "pod1"}
-		containers := []string{"ctr0"}
-		expectedGPUCount := 1
-		expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-		expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("Two pods sharing a global ResourceClaim with TimeSlicing and Default interval", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "basic-shared-claim-across-pods.yaml")
 		})
-		It("should have 1 GPU shared in time with default timeslice interval for each pod", func() {
-			var gpus []string
-			var logs string
-			var gpuPod0Ctr0, gpuPod1Ctr0 string
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should share 1 GPU between pods with default timeslice interval", func() {
+			namespace := "basic-shared-claim-across-pods"
+			pods := []string{"pod0", "pod1"}
+			containerName := "ctr0"
+			expectedGPUCount := 1
+			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
+			expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
+
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
+			var gpuPod0 string
 			for _, podName := range pods {
 				Eventually(func(g Gomega) {
 					By("checking that there is exactly 1 GPU")
-					gpus, logs = getGPUsFromPodLogs(namespace, podName, containers[0])
-					verifyGPUCount(g, gpus, expectedGPUCount, namespace, podName, containers[0])
-					if podName == "pod0" && containers[0] == "ctr0" {
-						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containers[0]))
-						gpuPod0Ctr0 = gpus[0]
-						claimNewGPU(g, gpuPod0Ctr0, namespace, podName, containers[0])
+					gpus, logs := getGPUsFromPodLogs(namespace, podName, containerName)
+					verifyGPUCount(g, gpus, expectedGPUCount, namespace, podName, containerName)
+					if podName == "pod0" {
+						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", podName))
+						gpuPod0 = gpus[0]
+						claimNewGPU(g, observedGPUs, gpuPod0, namespace, podName, containerName)
 					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU as of previous", containers[0]))
-						gpuPod1Ctr0 = gpus[0]
-						verifySharedGPU(g, gpuPod1Ctr0, gpuPod0Ctr0, namespace, podName, containers[0])
+						By(fmt.Sprintf("checking that %s claims the same GPU", podName))
+						verifySharedGPU(g, gpus[0], gpuPod0, namespace, podName, containerName)
 					}
-					verifyGPUProperties(g, logs, namespace, podName, containers[0], gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
+					verifyGPUProperties(g, logs, namespace, podName, containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
 				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 			}
 		})
 	})
-	Context("GPU sharing strategies: TimeSlicing with Long interval and SpacePartitioning", func() {
-		namespace := "basic-resourceclaim-opaque-config"
-		pods := []string{"pod0"}
-		tsContainers := []string{"ts-ctr0", "ts-ctr1"}
-		spContainers := []string{"sp-ctr0", "sp-ctr1"}
-		expectedGPUCount := 1
-		expectedTSSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-		expectedSPSharingStrategy := string(gpuv1alpha1.SpacePartitioningStrategy)
-		expectedPartitionCount := "10"
-		expectedTimeSliceInterval := string(gpuv1alpha1.LongTimeSlice)
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("GPU sharing strategies: TimeSlicing with Long interval and SpacePartitioning", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "basic-resourceclaim-opaque-config.yaml")
 		})
-		It("should have exactly 1 GPU shared in time with long timeslice interval for each container", func() {
-			var gpus []string
-			var logs string
-			var gpuTsCtr0, gpuTsCtr1 string
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should share GPUs with timeslicing (long interval) between ts containers", func() {
+			namespace := "basic-resourceclaim-opaque-config"
+			pods := []string{"pod0"}
+			tsContainers := []string{"ts-ctr0", "ts-ctr1"}
+			expectedGPUCount := 1
+			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
+			expectedTimeSliceInterval := string(gpuv1alpha1.LongTimeSlice)
+
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
+			var gpuTsCtr0 string
 			for _, containerName := range tsContainers {
 				Eventually(func(g Gomega) {
 					By("checking that there is exactly 1 GPU")
-					gpus, logs = getGPUsFromPodLogs(namespace, pods[0], containerName)
+					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
 					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
 					if containerName == "ts-ctr0" {
 						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
 						gpuTsCtr0 = gpus[0]
-						claimNewGPU(g, gpuTsCtr0, namespace, pods[0], containerName)
+						claimNewGPU(g, observedGPUs, gpuTsCtr0, namespace, pods[0], containerName)
 					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU as of previous", containerName))
-						gpuTsCtr1 = gpus[0]
-						verifySharedGPU(g, gpuTsCtr1, gpuTsCtr0, namespace, pods[0], containerName)
+						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
+						verifySharedGPU(g, gpus[0], gpuTsCtr0, namespace, pods[0], containerName)
 					}
-					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedTSSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
+					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
 				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 			}
 		})
-		It("should have exactly 1 GPU shared in space for each container", func() {
-			var gpus []string
-			var logs string
-			var gpuSpCtr0, gpuSpCtr1 string
+
+		It("should share GPUs with space partitioning between sp containers", func() {
+			namespace := "basic-resourceclaim-opaque-config"
+			pods := []string{"pod0"}
+			spContainers := []string{"sp-ctr0", "sp-ctr1"}
+			expectedGPUCount := 1
+			expectedSharingStrategy := string(gpuv1alpha1.SpacePartitioningStrategy)
+			expectedPartitionCount := "10"
+
+			observedGPUs := make(map[string]string)
+			var gpuSpCtr0 string
 			for _, containerName := range spContainers {
 				Eventually(func(g Gomega) {
 					By("checking that there is exactly 1 GPU")
-					gpus, logs = getGPUsFromPodLogs(namespace, pods[0], containerName)
+					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
 					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
 					if containerName == "sp-ctr0" {
 						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
 						gpuSpCtr0 = gpus[0]
-						claimNewGPU(g, gpuSpCtr0, namespace, pods[0], containerName)
+						claimNewGPU(g, observedGPUs, gpuSpCtr0, namespace, pods[0], containerName)
 					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU as of previous", containerName))
-						gpuSpCtr1 = gpus[0]
-						verifySharedGPU(g, gpuSpCtr1, gpuSpCtr0, namespace, pods[0], containerName)
+						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
+						verifySharedGPU(g, gpus[0], gpuSpCtr0, namespace, pods[0], containerName)
 					}
-					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSPSharingStrategy, "PARTITION_COUNT", expectedPartitionCount)
+					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "PARTITION_COUNT", expectedPartitionCount)
 				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 			}
 		})
 	})
-	Context("InitContainer and container sharing one GPU with TimeSlicing and Default interval", func() {
-		namespace := "initcontainer-shared-gpu"
-		pods := []string{"pod0"}
-		containerNames := []string{"init0", "ctr0"}
-		expectedGPUCount := 1
-		expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-		expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("InitContainer and container sharing one GPU with TimeSlicing and Default interval", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "initcontainer-shared-gpu.yaml")
 		})
-		It("should have exactly 1 unclaimed GPU shared in time with default timeslice interval", func() {
-			var gpus []string
-			var logs string
-			var gpuInit0, gpuCtr0 string
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should share 1 GPU between init container and regular container", func() {
+			namespace := "initcontainer-shared-gpu"
+			pods := []string{"pod0"}
+			containerNames := []string{"init0", "ctr0"}
+			expectedGPUCount := 1
+			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
+			expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
+
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
+			var gpuInit0 string
 			for _, containerName := range containerNames {
 				Eventually(func(g Gomega) {
 					By("checking that there is exactly 1 GPU")
-					gpus, logs = getGPUsFromPodLogs(namespace, pods[0], containerName)
+					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
 					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
 					if containerName == "init0" {
 						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
 						gpuInit0 = gpus[0]
-						claimNewGPU(g, gpuInit0, namespace, pods[0], containerName)
+						claimNewGPU(g, observedGPUs, gpuInit0, namespace, pods[0], containerName)
 					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU as of previous", containerName))
-						gpuCtr0 = gpus[0]
-						verifySharedGPU(g, gpuCtr0, gpuInit0, namespace, pods[0], containerName)
+						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
+						verifySharedGPU(g, gpus[0], gpuInit0, namespace, pods[0], containerName)
 					}
 					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
 				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 			}
 		})
 	})
-	Context("DRA AdminAccess set to true", func() {
-		namespace := "admin-access"
-		pods := []string{"pod0"}
-		containerName := "ctr0"
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("DRA AdminAccess set to true", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "admin-access.yaml")
 		})
+		AfterEach(func() {
+			cleanup()
+		})
+
 		It("should have DRA_ADMIN_ACCESS set to true", func() {
+			namespace := "admin-access"
+			pods := []string{"pod0"}
+			containerName := "ctr0"
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
 			verifyDRAAdminAccess(namespace, pods[0], containerName, "true")
 		})
 	})
-	Context("CEL expression selector for single GPU", func() {
-		namespace := "cel-selector"
-		pods := []string{"pod0"}
-		containerNames := []string{"ctr0"}
-		expectedGPUCount := 1
 
-		It("should have all the pods ready and running", func() {
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+	Context("CEL expression selector for single GPU", func() {
+		var cleanup func()
+		BeforeEach(func(ctx SpecContext) {
+			cleanup = deployManifest(ctx, "cel-selector.yaml")
 		})
-		It("should have exactly 1 unclaimed GPU selected using cel expression", func() {
-			verifyGPUAllocation(namespace, pods[0], containerNames[0], expectedGPUCount)
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("should allocate 1 GPU selected using CEL expression", func() {
+			namespace := "cel-selector"
+			pods := []string{"pod0"}
+			containerName := "ctr0"
+			expectedGPUCount := 1
+			checkPodsReadyAndRunning(namespace, pods, len(pods))
+
+			observedGPUs := make(map[string]string)
+			verifyGPUAllocation(namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 		})
 	})
+
 	Context("Webhooks", func() {
 		tests := []struct {
 			name     string
@@ -265,5 +322,4 @@ var _ = Describe("Test GPU allocation", func() {
 			})
 		}
 	})
-
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -28,275 +28,137 @@ import (
 )
 
 var _ = Describe("Test GPU allocation", func() {
-	Context("Two pods, one container each, one GPU per container", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "basic-resourceclaimtemplate.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
+	It("should allocate 1 distinct GPU per pod", func(ctx SpecContext) {
+		namespace := "basic-resourceclaimtemplate"
+		pods := []string{"pod0", "pod1"}
+		containerName := "ctr0"
+		expectedGPUCount := 1
 
-		It("should allocate 1 distinct GPU per pod", func() {
-			namespace := "basic-resourceclaimtemplate"
-			pods := []string{"pod0", "pod1"}
-			containerName := "ctr0"
-			expectedGPUCount := 1
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+		deployManifest(ctx, namespace, "basic-resourceclaimtemplate.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
 
-			observedGPUs := make(map[string]string)
-			for _, podName := range pods {
-				verifyGPUAllocation(namespace, podName, containerName, expectedGPUCount, observedGPUs)
-			}
+		observedGPUs := make(map[string]string)
+		for _, podName := range pods {
+			verifyGPUAllocation(ctx, namespace, podName, containerName, expectedGPUCount, observedGPUs)
+		}
+	})
+
+	It("should allocate 2 distinct GPUs to a single container", func(ctx SpecContext) {
+		namespace := "basic-multiple-requests"
+		pods := []string{"pod0"}
+		containerName := "ctr0"
+		expectedGPUCount := 2
+
+		deployManifest(ctx, namespace, "basic-multiple-requests.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+
+		observedGPUs := make(map[string]string)
+		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
+	})
+
+	It("should share 1 GPU between containers with TimeSlicing default interval", func(ctx SpecContext) {
+		namespace := "basic-shared-claim-across-containers"
+		pods := []string{"pod0"}
+
+		deployManifest(ctx, namespace, "basic-shared-claim-across-containers.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+
+		verifySharedGPUGroup(ctx, namespace, sharingGroup{
+			members: []podContainer{
+				{pod: "pod0", container: "ctr0"},
+				{pod: "pod0", container: "ctr1"},
+			},
+			expectedStrategy:  string(gpuv1alpha1.TimeSlicingStrategy),
+			expectedProperty:  "TIMESLICE_INTERVAL",
+			expectedPropValue: string(gpuv1alpha1.DefaultTimeSlice),
 		})
 	})
 
-	Context("One pod, one container with two GPUs", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "basic-multiple-requests.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
+	It("should share 1 GPU between pods with TimeSlicing default interval", func(ctx SpecContext) {
+		namespace := "basic-shared-claim-across-pods"
+		pods := []string{"pod0", "pod1"}
 
-		It("should allocate 2 distinct GPUs to a single container", func() {
-			namespace := "basic-multiple-requests"
-			pods := []string{"pod0"}
-			containerName := "ctr0"
-			expectedGPUCount := 2
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
+		deployManifest(ctx, namespace, "basic-shared-claim-across-pods.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
 
-			observedGPUs := make(map[string]string)
-			verifyGPUAllocation(namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
+		verifySharedGPUGroup(ctx, namespace, sharingGroup{
+			members: []podContainer{
+				{pod: "pod0", container: "ctr0"},
+				{pod: "pod1", container: "ctr0"},
+			},
+			expectedStrategy:  string(gpuv1alpha1.TimeSlicingStrategy),
+			expectedProperty:  "TIMESLICE_INTERVAL",
+			expectedPropValue: string(gpuv1alpha1.DefaultTimeSlice),
 		})
 	})
 
-	Context("One pod, two containers sharing one GPU with TimeSlicing and Default interval", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "basic-shared-claim-across-containers.yaml")
+	It("should share GPUs with TimeSlicing and SpacePartitioning", func(ctx SpecContext) {
+		namespace := "basic-resourceclaim-opaque-config"
+		pods := []string{"pod0"}
+
+		deployManifest(ctx, namespace, "basic-resourceclaim-opaque-config.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+
+		verifySharedGPUGroup(ctx, namespace, sharingGroup{
+			members: []podContainer{
+				{pod: "pod0", container: "ts-ctr0"},
+				{pod: "pod0", container: "ts-ctr1"},
+			},
+			expectedStrategy:  string(gpuv1alpha1.TimeSlicingStrategy),
+			expectedProperty:  "TIMESLICE_INTERVAL",
+			expectedPropValue: string(gpuv1alpha1.LongTimeSlice),
 		})
-		AfterEach(func() {
-			cleanup()
-		})
 
-		It("should share 1 GPU between containers with default timeslice interval", func() {
-			namespace := "basic-shared-claim-across-containers"
-			pods := []string{"pod0"}
-			containerNames := []string{"ctr0", "ctr1"}
-			expectedGPUCount := 1
-			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-			expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
-
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
-
-			observedGPUs := make(map[string]string)
-			var gpuCtr0 string
-			for _, containerName := range containerNames {
-				Eventually(func(g Gomega) {
-					By("checking that there is exactly 1 GPU")
-					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
-					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
-					if containerName == "ctr0" {
-						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
-						gpuCtr0 = gpus[0]
-						claimNewGPU(g, observedGPUs, gpus[0], namespace, pods[0], containerName)
-					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
-						verifySharedGPU(g, gpus[0], gpuCtr0, namespace, pods[0], containerName)
-					}
-					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
-				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
-			}
+		verifySharedGPUGroup(ctx, namespace, sharingGroup{
+			members: []podContainer{
+				{pod: "pod0", container: "sp-ctr0"},
+				{pod: "pod0", container: "sp-ctr1"},
+			},
+			expectedStrategy:  string(gpuv1alpha1.SpacePartitioningStrategy),
+			expectedProperty:  "PARTITION_COUNT",
+			expectedPropValue: "10",
 		})
 	})
 
-	Context("Two pods sharing a global ResourceClaim with TimeSlicing and Default interval", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "basic-shared-claim-across-pods.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
+	It("should share 1 GPU between init container and regular container", func(ctx SpecContext) {
+		namespace := "initcontainer-shared-gpu"
+		pods := []string{"pod0"}
 
-		It("should share 1 GPU between pods with default timeslice interval", func() {
-			namespace := "basic-shared-claim-across-pods"
-			pods := []string{"pod0", "pod1"}
-			containerName := "ctr0"
-			expectedGPUCount := 1
-			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-			expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
+		deployManifest(ctx, namespace, "initcontainer-shared-gpu.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
 
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
-
-			observedGPUs := make(map[string]string)
-			var gpuPod0 string
-			for _, podName := range pods {
-				Eventually(func(g Gomega) {
-					By("checking that there is exactly 1 GPU")
-					gpus, logs := getGPUsFromPodLogs(namespace, podName, containerName)
-					verifyGPUCount(g, gpus, expectedGPUCount, namespace, podName, containerName)
-					if podName == "pod0" {
-						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", podName))
-						gpuPod0 = gpus[0]
-						claimNewGPU(g, observedGPUs, gpuPod0, namespace, podName, containerName)
-					} else {
-						By(fmt.Sprintf("checking that %s claims the same GPU", podName))
-						verifySharedGPU(g, gpus[0], gpuPod0, namespace, podName, containerName)
-					}
-					verifyGPUProperties(g, logs, namespace, podName, containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
-				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
-			}
+		verifySharedGPUGroup(ctx, namespace, sharingGroup{
+			members: []podContainer{
+				{pod: "pod0", container: "init0"},
+				{pod: "pod0", container: "ctr0"},
+			},
+			expectedStrategy:  string(gpuv1alpha1.TimeSlicingStrategy),
+			expectedProperty:  "TIMESLICE_INTERVAL",
+			expectedPropValue: string(gpuv1alpha1.DefaultTimeSlice),
 		})
 	})
 
-	Context("GPU sharing strategies: TimeSlicing with Long interval and SpacePartitioning", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "basic-resourceclaim-opaque-config.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
+	It("should have DRA_ADMIN_ACCESS set to true", func(ctx SpecContext) {
+		namespace := "admin-access"
+		pods := []string{"pod0"}
+		containerName := "ctr0"
 
-		It("should share GPUs with timeslicing (long interval) between ts containers", func() {
-			namespace := "basic-resourceclaim-opaque-config"
-			pods := []string{"pod0"}
-			tsContainers := []string{"ts-ctr0", "ts-ctr1"}
-			expectedGPUCount := 1
-			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-			expectedTimeSliceInterval := string(gpuv1alpha1.LongTimeSlice)
-
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
-
-			observedGPUs := make(map[string]string)
-			var gpuTsCtr0 string
-			for _, containerName := range tsContainers {
-				Eventually(func(g Gomega) {
-					By("checking that there is exactly 1 GPU")
-					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
-					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
-					if containerName == "ts-ctr0" {
-						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
-						gpuTsCtr0 = gpus[0]
-						claimNewGPU(g, observedGPUs, gpuTsCtr0, namespace, pods[0], containerName)
-					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
-						verifySharedGPU(g, gpus[0], gpuTsCtr0, namespace, pods[0], containerName)
-					}
-					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
-				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
-			}
-		})
-
-		It("should share GPUs with space partitioning between sp containers", func() {
-			namespace := "basic-resourceclaim-opaque-config"
-			pods := []string{"pod0"}
-			spContainers := []string{"sp-ctr0", "sp-ctr1"}
-			expectedGPUCount := 1
-			expectedSharingStrategy := string(gpuv1alpha1.SpacePartitioningStrategy)
-			expectedPartitionCount := "10"
-
-			observedGPUs := make(map[string]string)
-			var gpuSpCtr0 string
-			for _, containerName := range spContainers {
-				Eventually(func(g Gomega) {
-					By("checking that there is exactly 1 GPU")
-					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
-					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
-					if containerName == "sp-ctr0" {
-						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
-						gpuSpCtr0 = gpus[0]
-						claimNewGPU(g, observedGPUs, gpuSpCtr0, namespace, pods[0], containerName)
-					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
-						verifySharedGPU(g, gpus[0], gpuSpCtr0, namespace, pods[0], containerName)
-					}
-					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "PARTITION_COUNT", expectedPartitionCount)
-				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
-			}
-		})
+		deployManifest(ctx, namespace, "admin-access.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+		verifyDRAAdminAccess(ctx, namespace, pods[0], containerName, "true")
 	})
 
-	Context("InitContainer and container sharing one GPU with TimeSlicing and Default interval", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "initcontainer-shared-gpu.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
+	It("should allocate 1 GPU selected using CEL expression", func(ctx SpecContext) {
+		namespace := "cel-selector"
+		pods := []string{"pod0"}
+		containerName := "ctr0"
+		expectedGPUCount := 1
 
-		It("should share 1 GPU between init container and regular container", func() {
-			namespace := "initcontainer-shared-gpu"
-			pods := []string{"pod0"}
-			containerNames := []string{"init0", "ctr0"}
-			expectedGPUCount := 1
-			expectedSharingStrategy := string(gpuv1alpha1.TimeSlicingStrategy)
-			expectedTimeSliceInterval := string(gpuv1alpha1.DefaultTimeSlice)
+		deployManifest(ctx, namespace, "cel-selector.yaml")
+		checkPodsReadyAndRunning(ctx, namespace, pods)
 
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
-
-			observedGPUs := make(map[string]string)
-			var gpuInit0 string
-			for _, containerName := range containerNames {
-				Eventually(func(g Gomega) {
-					By("checking that there is exactly 1 GPU")
-					gpus, logs := getGPUsFromPodLogs(namespace, pods[0], containerName)
-					verifyGPUCount(g, gpus, expectedGPUCount, namespace, pods[0], containerName)
-					if containerName == "init0" {
-						By(fmt.Sprintf("checking that the GPU is unclaimed for %s", containerName))
-						gpuInit0 = gpus[0]
-						claimNewGPU(g, observedGPUs, gpuInit0, namespace, pods[0], containerName)
-					} else {
-						By(fmt.Sprintf("checking that container %s claims the same GPU", containerName))
-						verifySharedGPU(g, gpus[0], gpuInit0, namespace, pods[0], containerName)
-					}
-					verifyGPUProperties(g, logs, namespace, pods[0], containerName, gpus, expectedSharingStrategy, "TIMESLICE_INTERVAL", expectedTimeSliceInterval)
-				}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
-			}
-		})
-	})
-
-	Context("DRA AdminAccess set to true", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "admin-access.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
-
-		It("should have DRA_ADMIN_ACCESS set to true", func() {
-			namespace := "admin-access"
-			pods := []string{"pod0"}
-			containerName := "ctr0"
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
-			verifyDRAAdminAccess(namespace, pods[0], containerName, "true")
-		})
-	})
-
-	Context("CEL expression selector for single GPU", func() {
-		var cleanup func()
-		BeforeEach(func(ctx SpecContext) {
-			cleanup = deployManifest(ctx, "cel-selector.yaml")
-		})
-		AfterEach(func() {
-			cleanup()
-		})
-
-		It("should allocate 1 GPU selected using CEL expression", func() {
-			namespace := "cel-selector"
-			pods := []string{"pod0"}
-			containerName := "ctr0"
-			expectedGPUCount := 1
-			checkPodsReadyAndRunning(namespace, pods, len(pods))
-
-			observedGPUs := make(map[string]string)
-			verifyGPUAllocation(namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
-		})
+		observedGPUs := make(map[string]string)
+		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 	})
 
 	Context("Webhooks", func() {


### PR DESCRIPTION
Fixes part of #171 
Refactors the e2e tests to make each test self-contained, improve failure diagnostics, and reduce boilerplate. Split into two commits for easier review.

## Commit 1: Make tests self-contained

- Each test deploys its own manifest via `BeforeEach`/`AfterEach` instead of deploying all 8 manifests at once in `BeforeSuite`
- `observedGPUs` is now per-test (verifies distinct GPUs within a test, not across tests)
- `BeforeSuite` only sets up K8s clients and verifies webhook readiness
- `AfterSuite` removed as cleanup is per-test
- `checkPodsReadyAndRunning` uses `Gomega` callback style with pod phase/conditions in errors
- Tests can now run in any order

## Commit 2: Reduce boilerplate and add failure diagnostics

- Flattens `Context`/`It` nesting to single `It` blocks with `deployManifest(ctx, namespace, file)` 
- `deployManifest` handles deploy, cleanup (with timeout), and failure diagnostics via `DeferCleanup` (LIFO ordering ensures diagnostics run before cleanup)
- Adds `verifySharedGPUGroup` helper — sharing tests (3, 4, 5, 6) go from ~20 lines of loop+branch each to a single call
- `getGPUsFromPodLogs` now takes a `Gomega` parameter so transient log-fetch errors retry within `Eventually` instead of immediately failing
- On failure, `kubectl describe pods`, `kubectl get events`, and driver logs are automatically dumped to test output
- Drops redundant `expectedPodCount` parameter from `checkPodsReadyAndRunning` (was always `len(pods)`)