### PR TITLE
Add multi-arch container image support (amd64/arm64)

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -1,0 +1,24 @@
+name: Build multi-arch images
+
+on: [ push, pull_request ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-multiarch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+    - name: Build multi-arch images
+      run: |
+        docker buildx build --pull \
+          --platform linux/amd64,linux/arm64 \
+          --build-arg GOLANG_VERSION="1.25.5" \
+          --build-arg BASE_IMAGE="docker.io/ubuntu:22.04" \
+          --build-arg VERSION="ci-test" \
+          -f deployments/container/Dockerfile \
+          .

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ DOCKER_TARGETS := $(patsubst %,docker-%, $(TARGETS))
 .PHONY: $(TARGETS) $(DOCKER_TARGETS)
 
 GOOS ?= linux
+GOARCH ?=
 
 binaries: cmds
 ifneq ($(PREFIX),)
@@ -45,15 +46,15 @@ cmd-%: COMMAND_BUILD_OPTIONS = -o $(PREFIX)/$(*)
 endif
 cmds: $(CMD_TARGETS)
 $(CMD_TARGETS): cmd-%:
-	CGO_LDFLAGS_ALLOW='-Wl,--unresolved-symbols=ignore-in-object-files' GOOS=$(GOOS) \
+	CGO_LDFLAGS_ALLOW='-Wl,--unresolved-symbols=ignore-in-object-files' GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		go build -ldflags "-s -w -X main.version=$(VERSION)" $(COMMAND_BUILD_OPTIONS) $(MODULE)/cmd/$(*)
 
 build:
-	GOOS=$(GOOS) go build ./...
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build ./...
 
 examples: $(EXAMPLE_TARGETS)
 $(EXAMPLE_TARGETS): example-%:
-	GOOS=$(GOOS) go build ./examples/$(*)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build ./examples/$(*)
 
 all: check test build binary
 check: $(CHECK_TARGETS)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,9 +4,14 @@ options:
   machineType: E2_HIGHCPU_32
 steps:
 - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251110-7ccd542560 # Go 1.25
-  entrypoint: make
+  entrypoint: bash
   env:
   - DRIVER_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver
   - DRIVER_CHART_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/dra-example-driver/charts
+  - MULTI_ARCH=true
   args:
-    - push-release-artifacts
+    - -c
+    - |
+      docker buildx create --name multiarch-builder --driver docker-container --use
+      docker buildx inspect --bootstrap
+      make push-release-artifacts

--- a/demo/scripts/build-driver-image.sh
+++ b/demo/scripts/build-driver-image.sh
@@ -45,4 +45,8 @@ export CONTAINER_TOOL="${CONTAINER_TOOL}"
 
 # Regenerate the CRDs and build the container image
 make docker-generate
-make -f deployments/container/Makefile "${DRIVER_IMAGE_PLATFORM}"
+
+# When MULTI_ARCH is set, build and push are combined in push-driver-image.sh
+if [ "${MULTI_ARCH}" != "true" ]; then
+    make -f deployments/container/Makefile "${DRIVER_IMAGE_PLATFORM}"
+fi

--- a/demo/scripts/push-driver-image.sh
+++ b/demo/scripts/push-driver-image.sh
@@ -28,4 +28,8 @@ export IMAGE="${DRIVER_IMAGE_NAME}"
 export VERSION="${DRIVER_IMAGE_TAG}"
 export CONTAINER_TOOL="${CONTAINER_TOOL}"
 
-make -f deployments/container/Makefile push
+if [ "${MULTI_ARCH}" = "true" ]; then
+    make -f deployments/container/Makefile "${DRIVER_IMAGE_PLATFORM}-push-multiarch"
+else
+    make -f deployments/container/Makefile push
+fi

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -14,13 +14,16 @@
 
 ARG GOLANG_VERSION=undefined
 ARG BASE_IMAGE=undefined
-FROM golang:${GOLANG_VERSION} AS build
+FROM --platform=${BUILDPLATFORM} golang:${GOLANG_VERSION} AS build
+
+ARG TARGETARCH
+ARG TARGETOS=linux
 
 WORKDIR /build
 COPY . .
 
 RUN mkdir /artifacts
-RUN make PREFIX=/artifacts cmds
+RUN GOARCH=${TARGETARCH} GOOS=${TARGETOS} make PREFIX=/artifacts cmds
 
 FROM ${BASE_IMAGE}
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -17,6 +17,7 @@ CONTAINER_TOOL ?= docker
 MKDIR ?= mkdir
 DISTRIBUTIONS := ubuntu22.04
 DOCKERFILE := $(CURDIR)/deployments/container/Dockerfile
+PLATFORMS ?= linux/amd64,linux/arm64
 
 include $(CURDIR)/common.mk
 
@@ -41,3 +42,20 @@ $(DISTRIBUTIONS):
 
 push:
 	$(CONTAINER_TOOL) push $(IMAGE)
+
+##### Multi-arch rules #####
+MULTIARCH_TARGETS := $(addsuffix -push-multiarch,$(DISTRIBUTIONS))
+.PHONY: $(MULTIARCH_TARGETS)
+
+ubuntu22.04-push-multiarch: BASE_IMAGE = docker.io/ubuntu:22.04
+
+$(MULTIARCH_TARGETS): %-push-multiarch:
+	$(CONTAINER_TOOL) buildx build --pull \
+		--platform $(PLATFORMS) \
+		--tag $(IMAGE) \
+		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
+		--build-arg VERSION="$(VERSION)" \
+		-f $(DOCKERFILE) \
+		--push \
+		$(CURDIR)


### PR DESCRIPTION
## Summary

Add multi-architecture container image build support for `linux/amd64` and `linux/arm64` using Docker buildx. This is needed for downstream consumers like [Kueue CI](https://github.com/openshift/release/pull/78156) that run on multi-arch clusters.

### Approach

The Dockerfile's build stage uses `--platform=$BUILDPLATFORM` so Go always compiles **natively** on the host architecture (no QEMU emulation needed). Cross-compilation is handled by passing `GOARCH=$TARGETARCH` to the Go build. Since the final stage has no `RUN` commands (only `COPY` and `LABEL`), no emulation is required for any target platform.

### Changes

- **`deployments/container/Dockerfile`**: Add `--platform=$BUILDPLATFORM` to the build stage and `TARGETARCH`/`TARGETOS` args for cross-compilation
- **`Makefile`**: Add `GOARCH` variable and pass it to all `go build` commands
- **`deployments/container/Makefile`**: Add `PLATFORMS` variable and `push-multiarch` targets using `docker buildx build --push --platform`
- **`demo/scripts/build-driver-image.sh`**: Skip local build when `MULTI_ARCH=true` (buildx combines build+push)
- **`demo/scripts/push-driver-image.sh`**: Call `*-push-multiarch` target when `MULTI_ARCH=true`
- **`cloudbuild.yaml`**: Set up buildx builder and enable `MULTI_ARCH=true` for release artifacts
- **`.github/workflows/multiarch.yaml`**: New CI workflow to verify multi-arch builds on every push/PR

### Backward compatibility

- Existing single-arch build targets are **unchanged**; `make -f deployments/container/Makefile ubuntu22.04` still works as before
- Multi-arch is opt-in via `MULTI_ARCH=true` env var (set automatically in Cloud Build)
- `PLATFORMS` defaults to `linux/amd64,linux/arm64` and can be overridden for additional architectures (e.g., `ppc64le`, `s390x`)

### Testing

- Verified Go cross-compilation produces correct ELF binaries for both architectures:
  - `x86-64` (amd64): `ELF 64-bit LSB executable, x86-64, statically linked`
  - `aarch64` (arm64): `ELF 64-bit LSB executable, ARM aarch64, statically linked`
- Verified Docker build with updated Dockerfile succeeds and correctly applies `TARGETARCH`/`TARGETOS`
- CI workflow added to validate multi-arch builds on PRs

/cc @klueska @pohly @byako