### PR TITLE
Fix Go version variable collision with Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ export CHART_GIT_TAG ?= $(shell git describe --tags --always --dirty --match 'ch
 
 include $(CURDIR)/common.mk
 
-BUILDIMAGE_TAG ?= golang$(GOLANG_VERSION)
+BUILDIMAGE_TAG ?= golang$(GO_VERSION)
 BUILDIMAGE ?= $(IMAGE_NAME)-build:$(BUILDIMAGE_TAG)
 
 CMDS := $(patsubst ./cmd/%/,%,$(sort $(dir $(wildcard ./cmd/*/))))
@@ -129,7 +129,7 @@ teardown-e2e:
 	if [ x"$(SKIP_IMAGE_BUILD)" = x"" ]; then \
 		$(CONTAINER_TOOL) build \
 			--progress=plain \
-			--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+			--build-arg GO_VERSION="$(GO_VERSION)" \
 			--tag $(BUILDIMAGE) \
 			-f $(^) \
 			docker; \

--- a/common.mk
+++ b/common.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GOLANG_VERSION ?= 1.26.2
+GO_VERSION ?= 1.26.2
 
 DRIVER_NAME := dra-example-driver
 MODULE := sigs.k8s.io/$(DRIVER_NAME)

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=undefined
+ARG GO_VERSION=undefined
 ARG BASE_IMAGE=undefined
-FROM golang:${GOLANG_VERSION} AS build
+FROM golang:${GO_VERSION} AS build
 
 WORKDIR /build
 COPY . .

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -33,7 +33,7 @@ $(DISTRIBUTIONS):
 	DOCKER_BUILDKIT=1 \
 		$(CONTAINER_TOOL) build --pull \
 		--tag $(IMAGE) \
-		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+		--build-arg GO_VERSION="$(GO_VERSION)" \
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
 		--build-arg VERSION="$(VERSION)" \
 		-f $(DOCKERFILE) \

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG GOLANG_VERSION=x.x.x
-FROM golang:${GOLANG_VERSION}
+ARG GO_VERSION=x.x.x
+FROM golang:${GO_VERSION}
 
 RUN go install github.com/gordonklaus/ineffassign@latest && \
     go install github.com/client9/misspell/cmd/misspell@latest


### PR DESCRIPTION
#188 broke the postsubmit image push job when it bumped Go to 1.26: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-dra-example-driver-image/2049630160541454336

Upstream Go Docker images (and images based on them like the gcb-docker-gcloud image in cloudbuild.yaml) set the `GOLANG_VERSION` variable to reflect the version of the local toolchain installed in the image. Separately (AFAICT), the scripts here use the `GOLANG_VERSION` variable as input to select a build image. Since cloudbuild.yaml defines an image using Go 1.25 (and `GOLANG_VERSION=1.25.x`), `golang:1.25.x` base images which defined `GOTOOLCHAIN=local` are used which fail to operate against our module which specifies Go 1.26.0.

Renaming the variable our scripts use to `GO_VERSION` avoids this conflict and allows the version defined in common.mk to take precedence over the value defined by the build image without any potential side-effects from the image's `GOLANG_VERSION` drifting from its actual toolchain version.