### PR TITLE
build: support proxy build args for image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,18 @@ include $(CURDIR)/common.mk
 BUILDIMAGE_TAG ?= golang$(GOLANG_VERSION)
 BUILDIMAGE ?= $(IMAGE_NAME)-build:$(BUILDIMAGE_TAG)
 
+# Proxy build arguments (passed only if the corresponding environment variables are set)
+PROXY_BUILD_ARGS :=
+ifneq ($(HTTP_PROXY),)
+PROXY_BUILD_ARGS += --build-arg HTTP_PROXY=$(HTTP_PROXY)
+endif
+ifneq ($(HTTPS_PROXY),)
+PROXY_BUILD_ARGS += --build-arg HTTPS_PROXY=$(HTTPS_PROXY)
+endif
+ifneq ($(NO_PROXY),)
+PROXY_BUILD_ARGS += --build-arg NO_PROXY=$(NO_PROXY)
+endif
+
 CMDS := $(patsubst ./cmd/%/,%,$(sort $(dir $(wildcard ./cmd/*/))))
 CMD_TARGETS := $(patsubst %,cmd-%, $(CMDS))
 
@@ -130,6 +142,7 @@ teardown-e2e:
 		$(CONTAINER_TOOL) build \
 			--progress=plain \
 			--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+			$(PROXY_BUILD_ARGS) \
 			--tag $(BUILDIMAGE) \
 			-f $(^) \
 			docker; \

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -16,6 +16,16 @@ ARG GOLANG_VERSION=undefined
 ARG BASE_IMAGE=undefined
 FROM golang:${GOLANG_VERSION} AS build
 
+# Proxy arguments (optional)
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+# Set proxy environment variables only if they are provided as build args
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV NO_PROXY=${NO_PROXY}
+
 WORKDIR /build
 COPY . .
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -23,6 +23,18 @@ include $(CURDIR)/common.mk
 IMAGE_TAG := $(VERSION)
 IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
 
+# Proxy build arguments (passed only if the corresponding environment variables are set)
+PROXY_BUILD_ARGS :=
+ifneq ($(HTTP_PROXY),)
+PROXY_BUILD_ARGS += --build-arg HTTP_PROXY=$(HTTP_PROXY)
+endif
+ifneq ($(HTTPS_PROXY),)
+PROXY_BUILD_ARGS += --build-arg HTTPS_PROXY=$(HTTPS_PROXY)
+endif
+ifneq ($(NO_PROXY),)
+PROXY_BUILD_ARGS += --build-arg NO_PROXY=$(NO_PROXY)
+endif
+
 ##### Public rules #####
 .PHONY: $(DISTRIBUTIONS)
 
@@ -36,6 +48,7 @@ $(DISTRIBUTIONS):
 		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
 		--build-arg VERSION="$(VERSION)" \
+		$(PROXY_BUILD_ARGS) \
 		-f $(DOCKERFILE) \
 		$(CURDIR)
 

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -14,6 +14,16 @@
 ARG GOLANG_VERSION=x.x.x
 FROM golang:${GOLANG_VERSION}
 
+# Proxy arguments (optional)
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
+# Set proxy environment variables only if they are provided as build args
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV NO_PROXY=${NO_PROXY}
+
 RUN go install github.com/gordonklaus/ineffassign@latest && \
     go install github.com/client9/misspell/cmd/misspell@latest
 


### PR DESCRIPTION
## Summary
Support proxy build args for Docker image builds, enabling builds behind corporate/network proxies.

## What changed
- **Makefile**:
  Conditionally assemble `--build-arg` flags for `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` when the corresponding environment variables are set, and pass them to `docker build`.
- **deployments/container/Makefile**:
   Add the same conditional proxy build-arg logic for distribution image builds.
- **deployments/container/Dockerfile**:
  Declare `ARG` and `ENV` for `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` in the build stage.
- **docker/Dockerfile.devel**:
  Add the same `ARG`/`ENV` proxy handling for the development image.

## Why
Image builds fail in environments that require an proxy to reach external registries or package repositories. This change propagates proxy settings into the Docker build context so that package downloads and dependency fetches succeed behind a proxy.

## Behavior
- **Proxy env vars set**: proxy settings are forwarded into the build via `--build-arg` and applied as `ENV` inside the build stage.
- **Proxy env vars unset**: no additional build args are passed; behavior is unchanged from before.

## Impact
- Build-time only. No changes to runtime logic, APIs, or deployed artifacts.
