### PR TITLE
Add example for native resource requests

### DIFF
--- a/cmd/dra-example-kubeletplugin/cdi.go
+++ b/cmd/dra-example-kubeletplugin/cdi.go
@@ -25,6 +25,8 @@ import (
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
+
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 )
 
 const cdiCommonDeviceName = "common"
@@ -107,7 +109,7 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, devices PreparedDevi
 		claimEdits.Append(device.ContainerEdits)
 
 		cdiDevice := cdispec.Device{
-			Name:           fmt.Sprintf("%s-%s", claimUID, device.DeviceName),
+			Name:           fmt.Sprintf("%s-%s", claimUID, helpers.GetCDIDeviceID(device.DeviceName, (*string)(device.ShareID))),
 			ContainerEdits: *claimEdits.ContainerEdits,
 		}
 

--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -97,7 +97,7 @@ func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceap
 func (d *driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
 	logger := klog.FromContext(ctx)
 	logger.Info("Preparing claim", "uid", claim.UID, "namespace", claim.Namespace, "name", claim.Name)
-	preparedPBs, err := d.state.Prepare(ctx, claim)
+	preparedDevices, err := d.state.Prepare(ctx, claim)
 	if err != nil {
 		logger.Error(err, "Error preparing devices for claim", "uid", claim.UID)
 		return kubeletplugin.PrepareResult{
@@ -105,12 +105,13 @@ func (d *driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.Re
 		}
 	}
 	var prepared []kubeletplugin.Device
-	for _, preparedPB := range preparedPBs {
+	for _, preparedDevice := range preparedDevices {
 		prepared = append(prepared, kubeletplugin.Device{
-			Requests:     preparedPB.GetRequestNames(),
-			PoolName:     preparedPB.GetPoolName(),
-			DeviceName:   preparedPB.GetDeviceName(),
-			CDIDeviceIDs: preparedPB.GetCdiDeviceIds(),
+			Requests:     preparedDevice.GetRequestNames(),
+			PoolName:     preparedDevice.GetPoolName(),
+			DeviceName:   preparedDevice.GetDeviceName(),
+			CDIDeviceIDs: preparedDevice.GetCdiDeviceIds(),
+			ShareID:      preparedDevice.ShareID,
 		})
 	}
 

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/cpu"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/gpu"
 	"sigs.k8s.io/dra-example-driver/pkg/flags"
 )
@@ -54,6 +55,7 @@ type Flags struct {
 	driverName                    string
 	podUID                        string
 	gpuPartitions                 int
+	cpusPerNUMANode               int
 }
 
 type Config struct {
@@ -67,6 +69,9 @@ type Config struct {
 var validProfiles = map[string]func(flags Flags) profiles.Profile{
 	gpu.ProfileName: func(flags Flags) profiles.Profile {
 		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions)
+	},
+	cpu.ProfileName: func(flags Flags) profiles.Profile {
+		return cpu.NewProfile(flags.nodeName, flags.driverName, flags.numDevices, flags.cpusPerNUMANode)
 	},
 }
 
@@ -110,7 +115,7 @@ func newApp() *cli.App {
 		},
 		&cli.IntFlag{
 			Name:        "num-devices",
-			Usage:       "The number of devices to be generated. Only relevant for the " + gpu.ProfileName + " profile.",
+			Usage:       "Number of top-level devices to advertise: GPUs for the " + gpu.ProfileName + " profile, NUMA nodes for the " + cpu.ProfileName + " profile.",
 			Value:       8,
 			Destination: &flags.numDevices,
 			EnvVars:     []string{"NUM_DEVICES"},
@@ -161,6 +166,13 @@ func newApp() *cli.App {
 			Value:       0,
 			Destination: &flags.gpuPartitions,
 			EnvVars:     []string{"GPU_PARTITIONS"},
+		},
+		&cli.IntFlag{
+			Name:        "cpus-per-numa-node",
+			Usage:       "Number of CPUs each fake NUMA-node device advertises as consumable capacity. Only relevant for the " + cpu.ProfileName + " profile.",
+			Value:       4,
+			Destination: &flags.cpusPerNUMANode,
+			EnvVars:     []string{"CPUS_PER_NUMA_NODE"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/cpu"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/gpu"
 	"sigs.k8s.io/dra-example-driver/pkg/flags"
 )
@@ -56,6 +57,7 @@ type Flags struct {
 	gpuPartitions                 int
 	gpuDeviceStatus               bool
 	bindingConditions             bool
+	cpusPerNUMANode               int
 }
 
 type Config struct {
@@ -69,6 +71,9 @@ type Config struct {
 var validProfiles = map[string]func(flags Flags) profiles.Profile{
 	gpu.ProfileName: func(flags Flags) profiles.Profile {
 		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions, flags.gpuDeviceStatus, flags.bindingConditions)
+	},
+	cpu.ProfileName: func(flags Flags) profiles.Profile {
+		return cpu.NewProfile(flags.nodeName, flags.driverName, flags.numDevices, flags.cpusPerNUMANode)
 	},
 }
 
@@ -112,7 +117,7 @@ func newApp() *cli.App {
 		},
 		&cli.IntFlag{
 			Name:        "num-devices",
-			Usage:       "The number of devices to be generated. Only relevant for the " + gpu.ProfileName + " profile.",
+			Usage:       "Number of top-level devices to advertise: GPUs for the " + gpu.ProfileName + " profile, NUMA nodes for the " + cpu.ProfileName + " profile.",
 			Value:       8,
 			Destination: &flags.numDevices,
 			EnvVars:     []string{"NUM_DEVICES"},
@@ -176,6 +181,13 @@ func newApp() *cli.App {
 			Value:       false,
 			Destination: &flags.bindingConditions,
 			EnvVars:     []string{"BINDING_CONDITIONS"},
+		},
+		&cli.IntFlag{
+			Name:        "cpus-per-numa-node",
+			Usage:       "Number of CPUs each fake NUMA-node device advertises as consumable capacity. Only relevant for the " + cpu.ProfileName + " profile.",
+			Value:       4,
+			Destination: &flags.cpusPerNUMANode,
+			EnvVars:     []string{"CPUS_PER_NUMA_NODE"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -57,6 +57,7 @@ type Flags struct {
 	gpuPartitions                 int
 	gpuDeviceStatus               bool
 	bindingConditions             bool
+	cpuNUMANodes                  int
 	cpusPerNUMANode               int
 }
 
@@ -73,7 +74,7 @@ var validProfiles = map[string]func(flags Flags) profiles.Profile{
 		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions, flags.gpuDeviceStatus, flags.bindingConditions)
 	},
 	cpu.ProfileName: func(flags Flags) profiles.Profile {
-		return cpu.NewProfile(flags.nodeName, flags.driverName, flags.numDevices, flags.cpusPerNUMANode)
+		return cpu.NewProfile(flags.nodeName, flags.driverName, flags.cpuNUMANodes, flags.cpusPerNUMANode)
 	},
 }
 
@@ -117,7 +118,7 @@ func newApp() *cli.App {
 		},
 		&cli.IntFlag{
 			Name:        "num-devices",
-			Usage:       "Number of top-level devices to advertise: GPUs for the " + gpu.ProfileName + " profile, NUMA nodes for the " + cpu.ProfileName + " profile.",
+			Usage:       "The number of devices to be generated. Only relevant for the " + gpu.ProfileName + " profile.",
 			Value:       8,
 			Destination: &flags.numDevices,
 			EnvVars:     []string{"NUM_DEVICES"},
@@ -181,6 +182,13 @@ func newApp() *cli.App {
 			Value:       false,
 			Destination: &flags.bindingConditions,
 			EnvVars:     []string{"BINDING_CONDITIONS"},
+		},
+		&cli.IntFlag{
+			Name:        "cpu-numa-nodes",
+			Usage:       "Number of fake NUMA-node devices to advertise. Only relevant for the " + cpu.ProfileName + " profile.",
+			Value:       8,
+			Destination: &flags.cpuNUMANodes,
+			EnvVars:     []string{"CPU_NUMA_NODES"},
 		},
 		&cli.IntFlag{
 			Name:        "cpus-per-numa-node",

--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -43,6 +43,7 @@ import (
 	checkpointinstall "sigs.k8s.io/dra-example-driver/internal/api/checkpoint/install"
 	checkpointv1alpha1 "sigs.k8s.io/dra-example-driver/internal/api/checkpoint/v1"
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 )
 
 type AllocatableDevices map[string]resourceapi.Device
@@ -57,6 +58,9 @@ type PreparedDevice struct {
 	drapbv1.Device
 	ContainerEdits *cdiapi.ContainerEdits
 	AdminAccess    bool
+	// ShareID distinguishes one allocation of a device shared via consumable
+	// capacity; it is nil for exclusively allocated devices.
+	ShareID *types.UID
 }
 
 func (pds PreparedDevices) GetDevices() []*drapbv1.Device {
@@ -152,7 +156,7 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 	return state, nil
 }
 
-func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) ([]*drapbv1.Device, error) {
+func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) (PreparedDevices, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -165,7 +169,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		return nil, fmt.Errorf("unable to restore from checkpoint: %v", err)
 	}
 	if restoredDevices != nil {
-		return restoredDevices.GetDevices(), nil
+		return restoredDevices, nil
 	}
 
 	preparedDevices, err := s.prepareDevices(ctx, claim)
@@ -182,7 +186,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		return nil, fmt.Errorf("unable to sync to checkpoint: %v", err)
 	}
 
-	return preparedDevices.GetDevices(), nil
+	return preparedDevices, nil
 }
 
 func (s *DeviceState) Unprepare(claimUID types.UID) error {
@@ -330,15 +334,17 @@ func (s *DeviceState) computeDeviceConfig(claim *resourceapi.ResourceClaim) (Pre
 	var preparedDevices PreparedDevices
 	for _, results := range configResultsMap {
 		for _, result := range results {
+			deviceID := helpers.GetCDIDeviceID(result.Device, (*string)(result.ShareID))
 			device := &PreparedDevice{
 				Device: drapbv1.Device{
 					RequestNames: []string{result.Request},
 					PoolName:     result.Pool,
 					DeviceName:   result.Device,
-					CdiDeviceIds: s.cdi.GetClaimDevices(string(claim.UID), []string{result.Device}),
+					CdiDeviceIds: s.cdi.GetClaimDevices(string(claim.UID), []string{deviceID}),
 				},
-				ContainerEdits: perDeviceCDIContainerEdits[result.Device],
+				ContainerEdits: perDeviceCDIContainerEdits[deviceID],
 				AdminAccess:    hasAdminAccess,
+				ShareID:        result.ShareID,
 			}
 			preparedDevices = append(preparedDevices, device)
 		}

--- a/cmd/dra-example-kubeletplugin/state_test.go
+++ b/cmd/dra-example-kubeletplugin/state_test.go
@@ -17,11 +17,21 @@
 package main
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/dra-example-driver/internal/profiles/cpu"
 )
 
 func TestPreparedDevicesGetDevices(t *testing.T) {
@@ -53,4 +63,164 @@ func TestPreparedDevicesGetDevices(t *testing.T) {
 			assert.Equal(t, test.expected, devices)
 		})
 	}
+}
+
+// TestComputeDeviceConfigShareID verifies that the ShareID the scheduler
+// assigns to each allocation result is carried through to the prepared device,
+// which the kubelet plugin then forwards to the kubelet. This guards the
+// consumable-capacity sharing path: two allocations of the same device must
+// keep their distinct ShareIDs.
+func TestComputeDeviceConfigShareID(t *testing.T) {
+	const (
+		nodeName   = "test-node"
+		driverName = "cpu.example.com"
+	)
+
+	flags := &Flags{
+		cdiRoot:         t.TempDir(),
+		driverName:      driverName,
+		profile:         "cpu",
+		nodeName:        nodeName,
+		cpuNUMANodes:    1,
+		cpusPerNUMANode: 4,
+	}
+	state, err := NewDeviceState(&Config{
+		flags:   flags,
+		profile: cpu.NewProfile(nodeName, driverName, flags.cpuNUMANodes, flags.cpusPerNUMANode),
+	})
+	require.NoError(t, err)
+
+	result := func(request string, shareID *types.UID) resourceapi.DeviceRequestAllocationResult {
+		return resourceapi.DeviceRequestAllocationResult{
+			Request: request,
+			Driver:  driverName,
+			Pool:    nodeName,
+			Device:  "numa-0",
+			ShareID: shareID,
+		}
+	}
+
+	tests := map[string]struct {
+		results          []resourceapi.DeviceRequestAllocationResult
+		expectedShareIDs []*types.UID
+		// expectedCDISuffixes are CDI device-ID suffixes that must each appear
+		// on some prepared device, proving the ShareID is woven into the CDI
+		// device name so shares of one device stay distinct.
+		expectedCDISuffixes []string
+	}{
+		"no ShareID": {
+			results:             []resourceapi.DeviceRequestAllocationResult{result("cpus", nil)},
+			expectedShareIDs:    []*types.UID{nil},
+			expectedCDISuffixes: []string{"claim-uid-numa-0"},
+		},
+		"distinct ShareIDs sharing one device": {
+			results: []resourceapi.DeviceRequestAllocationResult{
+				result("cpus-0", ptr.To(types.UID("share-0"))),
+				result("cpus-1", ptr.To(types.UID("share-1"))),
+			},
+			expectedShareIDs:    []*types.UID{ptr.To(types.UID("share-0")), ptr.To(types.UID("share-1"))},
+			expectedCDISuffixes: []string{"claim-uid-numa-0-share-0", "claim-uid-numa-0-share-1"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			claim := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-uid"},
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{Results: test.results},
+					},
+				},
+			}
+
+			prepared, err := state.computeDeviceConfig(claim)
+			require.NoError(t, err)
+			require.Len(t, prepared, len(test.expectedShareIDs))
+
+			var shareIDs []*types.UID
+			var cdiDeviceIDs []string
+			for _, device := range prepared {
+				shareIDs = append(shareIDs, device.ShareID)
+				cdiDeviceIDs = append(cdiDeviceIDs, device.CdiDeviceIds...)
+			}
+			assert.ElementsMatch(t, test.expectedShareIDs, shareIDs)
+
+			for _, suffix := range test.expectedCDISuffixes {
+				matched := slices.ContainsFunc(cdiDeviceIDs, func(id string) bool {
+					return strings.HasSuffix(id, suffix)
+				})
+				assert.True(t, matched, "expected a CDI device ID ending with %q in %v", suffix, cdiDeviceIDs)
+			}
+		})
+	}
+}
+
+// TestComputeDeviceConfigSharedDeviceContainerEdits verifies that when one
+// device is allocated multiple times in a claim (consumable capacity), each
+// share keeps its own container edits keyed by the share-aware device id rather
+// than collapsing onto a single entry for the bare device name.
+func TestComputeDeviceConfigSharedDeviceContainerEdits(t *testing.T) {
+	const (
+		nodeName   = "test-node"
+		driverName = "cpu.example.com"
+	)
+
+	flags := &Flags{
+		cdiRoot:         t.TempDir(),
+		driverName:      driverName,
+		profile:         "cpu",
+		nodeName:        nodeName,
+		cpuNUMANodes:    1,
+		cpusPerNUMANode: 4,
+	}
+	state, err := NewDeviceState(&Config{
+		flags:   flags,
+		profile: cpu.NewProfile(nodeName, driverName, flags.cpuNUMANodes, flags.cpusPerNUMANode),
+	})
+	require.NoError(t, err)
+
+	capacityKey := resourceapi.QualifiedName(driverName + "/cpu")
+	result := func(request string, shareID types.UID, consumed string) resourceapi.DeviceRequestAllocationResult {
+		return resourceapi.DeviceRequestAllocationResult{
+			Request: request,
+			Driver:  driverName,
+			Pool:    nodeName,
+			Device:  "numa-0",
+			ShareID: ptr.To(shareID),
+			ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+				capacityKey: resource.MustParse(consumed),
+			},
+		}
+	}
+
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{UID: "claim-uid"},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{Results: []resourceapi.DeviceRequestAllocationResult{
+					result("cpu0", "share-0", "1"),
+					result("cpu1", "share-1", "3"),
+				}},
+			},
+		},
+	}
+
+	prepared, err := state.computeDeviceConfig(claim)
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+
+	consumedByShare := map[types.UID]string{}
+	for _, device := range prepared {
+		require.NotNil(t, device.ShareID)
+		require.NotNil(t, device.ContainerEdits)
+		require.NotNil(t, device.ContainerEdits.ContainerEdits)
+		for _, env := range device.ContainerEdits.Env {
+			if consumed, ok := strings.CutPrefix(env, "CPU_DEVICE_0_CONSUMED_CPU="); ok {
+				consumedByShare[*device.ShareID] = consumed
+			}
+		}
+	}
+	assert.Equal(t, "1", consumedByShare["share-0"], "share-0 should keep its own consumed CPU edit")
+	assert.Equal(t, "3", consumedByShare["share-1"], "share-1 should keep its own consumed CPU edit")
 }

--- a/cmd/dra-example-webhook/main.go
+++ b/cmd/dra-example-webhook/main.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/cpu"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/gpu"
 	"sigs.k8s.io/dra-example-driver/pkg/flags"
 )
@@ -53,6 +54,7 @@ type validator func(runtime.Object) error
 
 var validProfiles = map[string]profiles.ConfigHandler{
 	gpu.ProfileName: gpu.Profile{},
+	cpu.ProfileName: cpu.Profile{},
 }
 
 func main() {

--- a/demo/native-resource-request.yaml
+++ b/demo/native-resource-request.yaml
@@ -1,0 +1,91 @@
+# Example: Native (Node-Allocatable) Resource Requests via DRA
+#
+# One pod, one container.
+# The driver publishes one device per fake NUMA node, each exposing its CPU
+# count as consumable capacity. The container claims 2 CPUs of that capacity
+# through DRA. Because every NUMA device carries a `NodeAllocatableResourceMappings`
+# entry, kube-scheduler also debits 2 CPUs from the node's standard allocatable
+# budget for this pod — preventing oversubscription when CPUs are managed
+# through DRA alongside the classic resource request API.
+#
+# Because the NUMA device sets `AllowMultipleAllocations: true`, several pods
+# can claim CPUs from the same NUMA node until its capacity is exhausted.
+#
+# This example uses the `cpu` device profile rather than the default `gpu`
+# profile. It is intended to be installed as a separate driver release; it
+# does not replace an existing `gpu` install.
+#
+# Helm install (required before running this demo):
+#   helm upgrade -i \
+#     --create-namespace \
+#     --namespace dra-example-driver-cpu \
+#     --set deviceProfile=cpu \
+#     --set kubeletPlugin.numDevices=2 \
+#     --set kubeletPlugin.cpu.cpusPerNUMANode=4 \
+#     dra-example-driver-cpu \
+#     deployments/helm/dra-example-driver
+#
+# `kubeletPlugin.numDevices` here means the number of fake NUMA-node devices
+# the driver advertises. `kubeletPlugin.cpu.cpusPerNUMANode` controls how much
+# CPU capacity each NUMA device exposes.
+#
+# Expected: pod0 gets 2 CPUs of capacity from one NUMA device and the
+# scheduler records the native-resource accounting in pod.status. Check with:
+#   kubectl logs -n native-resource-request pod0 -c ctr0 | grep CPU_DEVICE
+#   kubectl get pod -n native-resource-request pod0 \
+#     -o jsonpath='{.status.nodeAllocatableResourceClaimStatuses}'
+# The status should include cpu: "2" for the generated claim. The
+# `resourceClaimName` in that status is the template-generated concrete claim
+# name, not the pod-local name `cpus`.
+#
+# Driver requirements:
+#   Profile: cpu
+#   NUMA nodes: >= 1, each with >= 2 CPUs of capacity
+#
+# Cluster requirements:
+#   Kubernetes 1.36+
+#   Feature gates: DRANodeAllocatableResources, DRAConsumableCapacity
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: native-resource-request
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: native-resource-request
+  name: two-cpus
+spec:
+  spec:
+    devices:
+      requests:
+      - name: cpus
+        exactly:
+          deviceClassName: cpu.example.com
+          capacity:
+            requests:
+              cpu.example.com/cpu: "2"
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: native-resource-request
+  name: pod0
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: cpus
+  resourceClaims:
+  - name: cpus
+    resourceClaimTemplateName: two-cpus

--- a/demo/native-resource-request.yaml
+++ b/demo/native-resource-request.yaml
@@ -1,46 +1,55 @@
-# Example: Native (Node-Allocatable) Resource Requests via DRA
+# Example: Native (Node-Allocatable) CPU Resources via DRA, with Sharing
 #
-# One pod, one container.
-# The driver publishes one device per fake NUMA node, each exposing its CPU
-# count as consumable capacity. The container claims 2 CPUs of that capacity
-# through DRA. Because every NUMA device carries a `NodeAllocatableResourceMappings`
-# entry, kube-scheduler also debits 2 CPUs from the node's standard allocatable
-# budget for this pod — preventing oversubscription when CPUs are managed
-# through DRA alongside the classic resource request API.
+# One pod, one ResourceClaim with two requests. The driver publishes one device
+# per fake NUMA node, each exposing its CPU count as consumable capacity. The
+# claim makes two requests of 1 CPU each; with a single NUMA node both requests
+# are satisfied by the *same* device.
 #
-# Because the NUMA device sets `AllowMultipleAllocations: true`, several pods
-# can claim CPUs from the same NUMA node until its capacity is exhausted.
+# Native resource accounting: every NUMA device carries a
+# `NodeAllocatableResourceMappings` entry, so kube-scheduler also debits the
+# claimed CPUs (2 here) from the node's standard allocatable budget, preventing
+# oversubscription when CPUs are managed through DRA alongside the classic
+# resource request API.
+#
+# Consumable-capacity sharing: the NUMA device sets
+# `AllowMultipleAllocations: true`, so its CPU capacity is split across the two
+# requests. The scheduler assigns each allocation a distinct ShareID, and the
+# driver uses the ShareID to expose the two shares of the one device as separate
+# CDI devices.
 #
 # This example uses the `cpu` device profile rather than the default `gpu`
-# profile. It is intended to be installed as a separate driver release; it
-# does not replace an existing `gpu` install.
+# profile. Install it as a separate driver release; it does not replace an
+# existing `gpu` install.
 #
 # Helm install (required before running this demo):
 #   helm upgrade -i \
 #     --create-namespace \
 #     --namespace dra-example-driver-cpu \
 #     --set deviceProfile=cpu \
-#     --set kubeletPlugin.numDevices=2 \
-#     --set kubeletPlugin.cpu.cpusPerNUMANode=4 \
+#     --set kubeletPlugin.cpu.numaNodes=1 \
+#     --set kubeletPlugin.cpu.cpusPerNUMANode=2 \
 #     dra-example-driver-cpu \
 #     deployments/helm/dra-example-driver
 #
-# `kubeletPlugin.numDevices` here means the number of fake NUMA-node devices
-# the driver advertises. `kubeletPlugin.cpu.cpusPerNUMANode` controls how much
-# CPU capacity each NUMA device exposes.
+# `kubeletPlugin.cpu.numaNodes` is the number of fake NUMA-node devices the
+# driver advertises; `kubeletPlugin.cpu.cpusPerNUMANode` is the CPU capacity
+# each one exposes. A single 2-CPU NUMA node satisfies both requests from one
+# device.
 #
-# Expected: pod0 gets 2 CPUs of capacity from one NUMA device and the
-# scheduler records the native-resource accounting in pod.status. Check with:
-#   kubectl logs -n native-resource-request pod0 -c ctr0 | grep CPU_DEVICE
+# Expected: pod0 runs with both requests served by one NUMA device. Check with:
+#   kubectl get pods -n native-resource-request
 #   kubectl get pod -n native-resource-request pod0 \
 #     -o jsonpath='{.status.nodeAllocatableResourceClaimStatuses}'
-# The status should include cpu: "2" for the generated claim. The
-# `resourceClaimName` in that status is the template-generated concrete claim
+#   kubectl get resourceclaims -n native-resource-request \
+#     -o jsonpath='{range .items[*].status.allocation.devices.results[*]}{.device}{" "}{.shareID}{"\n"}{end}'
+# The status should include cpu: "2" for the generated claim, and the two
+# allocation results should reference the same device with different ShareIDs.
+# The `resourceClaimName` in the status is the template-generated concrete claim
 # name, not the pod-local name `cpus`.
 #
 # Driver requirements:
 #   Profile: cpu
-#   NUMA nodes: >= 1, each with >= 2 CPUs of capacity
+#   NUMA nodes: 1, with >= 2 CPUs of capacity
 #
 # Cluster requirements:
 #   Kubernetes 1.36+
@@ -62,12 +71,18 @@ spec:
   spec:
     devices:
       requests:
-      - name: cpus
+      - name: cpu0
         exactly:
           deviceClassName: cpu.example.com
           capacity:
             requests:
-              cpu.example.com/cpu: "2"
+              cpu.example.com/cpu: "1"
+      - name: cpu1
+        exactly:
+          deviceClassName: cpu.example.com
+          capacity:
+            requests:
+              cpu.example.com/cpu: "1"
 
 ---
 apiVersion: v1

--- a/demo/scripts/kind-cluster-config.yaml
+++ b/demo/scripts/kind-cluster-config.yaml
@@ -7,6 +7,8 @@ featureGates:
   GangScheduling: true
   GenericWorkload: true
   DRAExtendedResource: true
+  DRANodeAllocatableResources: true
+  DRAConsumableCapacity: true
 containerdConfigPatches:
 # Enable CDI as described in
 # https://tags.cncf.io/container-device-interface#containerd-configuration

--- a/demo/scripts/kind-cluster-config.yaml
+++ b/demo/scripts/kind-cluster-config.yaml
@@ -8,6 +8,8 @@ featureGates:
   GenericWorkload: true
   DRAExtendedResource: true
   DRADeviceBindingConditions: true
+  DRANodeAllocatableResources: true
+  DRAConsumableCapacity: true
 runtimeConfig:
   resource.k8s.io/v1beta1: "true"
   scheduling.k8s.io/v1alpha2: "true"

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -86,6 +86,8 @@ spec:
         {{- end }}
         - name: GPU_PARTITIONS
           value: {{ .Values.kubeletPlugin.gpuPartitions | quote }}
+        - name: CPUS_PER_NUMA_NODE
+          value: {{ .Values.kubeletPlugin.cpu.cpusPerNUMANode | quote }}
         - name: POD_UID
           valueFrom:
             fieldRef:

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -88,6 +88,8 @@ spec:
         {{- end }}
         - name: GPU_PARTITIONS
           value: {{ .Values.kubeletPlugin.gpuPartitions | quote }}
+        - name: CPU_NUMA_NODES
+          value: {{ .Values.kubeletPlugin.cpu.numaNodes | quote }}
         - name: CPUS_PER_NUMA_NODE
           value: {{ .Values.kubeletPlugin.cpu.cpusPerNUMANode | quote }}
         - name: POD_UID

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -88,6 +88,8 @@ spec:
         {{- end }}
         - name: GPU_PARTITIONS
           value: {{ .Values.kubeletPlugin.gpuPartitions | quote }}
+        - name: CPUS_PER_NUMA_NODE
+          value: {{ .Values.kubeletPlugin.cpu.cpusPerNUMANode | quote }}
         - name: POD_UID
           valueFrom:
             fieldRef:

--- a/deployments/helm/dra-example-driver/values.schema.json
+++ b/deployments/helm/dra-example-driver/values.schema.json
@@ -4,7 +4,8 @@
     "deviceProfile": {
       "type": "string",
       "enum": [
-        "gpu"
+        "gpu",
+        "cpu"
       ]
     }
   }

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -45,13 +45,20 @@ serviceAccount:
   name: ""
 
 kubeletPlugin:
-  # numDevices describes how many GPUs to advertise on each node when the "gpu"
-  # deviceProfile is used. Not relevant for other profiles.
+  # numDevices is the number of top-level devices to advertise on each node.
+  # For the "gpu" profile this is the GPU count. For the "cpu" profile it is
+  # the number of fake NUMA-node devices (see cpu.cpusPerNUMANode below).
   numDevices: 8
   # gpuPartitions sets the number of partitions per GPU. When set to a value
   # greater than 0, GPUs are exposed with shared counters allowing flexible
   # partitioning (DRAPartitionableDevices feature). 0 disables partitioning.
   gpuPartitions: 0
+  # cpu groups options specific to the "cpu" device profile.
+  cpu:
+    # cpusPerNUMANode is the amount of CPU capacity each fake NUMA-node device
+    # advertises. With AllowMultipleAllocations enabled, multiple claims can
+    # share a NUMA device until its capacity is exhausted.
+    cpusPerNUMANode: 4
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -49,13 +49,20 @@ serviceAccount:
   name: ""
 
 kubeletPlugin:
-  # numDevices describes how many GPUs to advertise on each node when the "gpu"
-  # deviceProfile is used. Not relevant for other profiles.
+  # numDevices is the number of top-level devices to advertise on each node.
+  # For the "gpu" profile this is the GPU count. For the "cpu" profile it is
+  # the number of fake NUMA-node devices (see cpu.cpusPerNUMANode below).
   numDevices: 8
   # gpuPartitions sets the number of partitions per GPU. When set to a value
   # greater than 0, GPUs are exposed with shared counters allowing flexible
   # partitioning (DRAPartitionableDevices feature). 0 disables partitioning.
   gpuPartitions: 0
+  # cpu groups options specific to the "cpu" device profile.
+  cpu:
+    # cpusPerNUMANode is the amount of CPU capacity each fake NUMA-node device
+    # advertises. With AllowMultipleAllocations enabled, multiple claims can
+    # share a NUMA device until its capacity is exhausted.
+    cpusPerNUMANode: 4
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -49,9 +49,8 @@ serviceAccount:
   name: ""
 
 kubeletPlugin:
-  # numDevices is the number of top-level devices to advertise on each node.
-  # For the "gpu" profile this is the GPU count. For the "cpu" profile it is
-  # the number of fake NUMA-node devices (see cpu.cpusPerNUMANode below).
+  # numDevices is the number of GPU devices to advertise on each node. Only
+  # relevant for the "gpu" profile.
   numDevices: 8
   # gpuPartitions sets the number of partitions per GPU. When set to a value
   # greater than 0, GPUs are exposed with shared counters allowing flexible
@@ -59,6 +58,8 @@ kubeletPlugin:
   gpuPartitions: 0
   # cpu groups options specific to the "cpu" device profile.
   cpu:
+    # numaNodes is the number of fake NUMA-node devices to advertise.
+    numaNodes: 8
     # cpusPerNUMANode is the amount of CPU capacity each fake NUMA-node device
     # advertises. With AllowMultipleAllocations enabled, multiple claims can
     # share a NUMA device until its capacity is exhausted.

--- a/internal/profiles/cpu/cpu.go
+++ b/internal/profiles/cpu/cpu.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cpu
+
+import (
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
+	"k8s.io/utils/ptr"
+	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
+	cdispec "tags.cncf.io/container-device-interface/specs-go"
+
+	"sigs.k8s.io/dra-example-driver/internal/profiles"
+)
+
+const ProfileName = "cpu"
+
+// CPUCapacitySuffix is appended to the driver name (e.g. "cpu.example.com")
+// to form the per-device capacity key (e.g. "cpu.example.com/cpu"). Keeping
+// the key derived from the driver name lets multiple driver installs (with
+// distinct names) coexist without their capacity keys colliding.
+const CPUCapacitySuffix = "cpu"
+
+type Profile struct {
+	nodeName        string
+	driverName      string
+	numNUMANodes    int
+	cpusPerNUMANode int
+}
+
+func NewProfile(nodeName, driverName string, numNUMANodes, cpusPerNUMANode int) Profile {
+	return Profile{
+		nodeName:        nodeName,
+		driverName:      driverName,
+		numNUMANodes:    numNUMANodes,
+		cpusPerNUMANode: cpusPerNUMANode,
+	}
+}
+
+// CapacityKey returns the device-capacity key the profile uses to expose CPU
+// as consumable capacity. It is also the key user-facing ResourceClaims must
+// reference in `capacity.requests`.
+func (p Profile) CapacityKey() resourceapi.QualifiedName {
+	return resourceapi.QualifiedName(p.driverName + "/" + CPUCapacitySuffix)
+}
+
+func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
+	capacityKey := p.CapacityKey()
+	devices := make([]resourceapi.Device, p.numNUMANodes)
+	for i := 0; i < p.numNUMANodes; i++ {
+		devices[i] = resourceapi.Device{
+			Name:                     fmt.Sprintf("numa-%d", i),
+			AllowMultipleAllocations: ptr.To(true),
+			Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				"numaNodeID": {IntValue: ptr.To(int64(i))},
+			},
+			Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+				capacityKey: {Value: *resource.NewQuantity(int64(p.cpusPerNUMANode), resource.DecimalSI)},
+			},
+			NodeAllocatableResourceMappings: map[corev1.ResourceName]resourceapi.NodeAllocatableResourceMapping{
+				corev1.ResourceCPU: {CapacityKey: &capacityKey},
+			},
+		}
+	}
+
+	return resourceslice.DriverResources{
+		Pools: map[string]resourceslice.Pool{
+			p.nodeName: {Slices: []resourceslice.Slice{{Devices: devices}}},
+		},
+	}, nil
+}
+
+// SchemeBuilder implements [profiles.ConfigHandler]. The CPU profile does not
+// accept opaque configuration yet.
+func (p Profile) SchemeBuilder() runtime.SchemeBuilder {
+	return runtime.NewSchemeBuilder()
+}
+
+// Validate implements [profiles.ConfigHandler].
+func (p Profile) Validate(config runtime.Object) error {
+	if config != nil {
+		return errors.New("configuration not allowed")
+	}
+	return nil
+}
+
+// ApplyConfig implements [profiles.ConfigHandler]. It rejects any non-nil
+// configuration and otherwise injects env vars per allocated NUMA device so
+// the demo container can show which device was allocated and how much CPU
+// capacity was consumed.
+func (p Profile) ApplyConfig(config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (profiles.PerDeviceCDIContainerEdits, error) {
+	if config != nil {
+		return nil, errors.New("configuration not allowed")
+	}
+
+	capacityKey := p.CapacityKey()
+	edits := make(profiles.PerDeviceCDIContainerEdits, len(results))
+	for _, result := range results {
+		// Device names are "numa-<index>"; trim the prefix for the env var.
+		envID := result.Device[len("numa-"):]
+		envs := []string{
+			fmt.Sprintf("CPU_DEVICE_%s=%s", envID, result.Device),
+		}
+		if cpu, ok := result.ConsumedCapacity[capacityKey]; ok {
+			envs = append(envs, fmt.Sprintf("CPU_DEVICE_%s_CONSUMED_CPU=%s", envID, cpu.String()))
+		}
+		edits[result.Device] = &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+			Env: envs,
+		}}
+	}
+	return edits, nil
+}

--- a/internal/profiles/cpu/cpu.go
+++ b/internal/profiles/cpu/cpu.go
@@ -30,6 +30,7 @@ import (
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
 
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 )
 
 const ProfileName = "cpu"
@@ -123,7 +124,11 @@ func (p Profile) ApplyConfig(config runtime.Object, results []*resourceapi.Devic
 		if cpu, ok := result.ConsumedCapacity[capacityKey]; ok {
 			envs = append(envs, fmt.Sprintf("CPU_DEVICE_%s_CONSUMED_CPU=%s", envID, cpu.String()))
 		}
-		edits[result.Device] = &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
+		// Key edits by the share-aware device id so that multiple shares of one
+		// NUMA device (consumable capacity) keep their own edits instead of
+		// overwriting each other.
+		deviceID := helpers.GetCDIDeviceID(result.Device, (*string)(result.ShareID))
+		edits[deviceID] = &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{
 			Env: envs,
 		}}
 	}

--- a/internal/profiles/cpu/cpu_test.go
+++ b/internal/profiles/cpu/cpu_test.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cpu
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestNewProfile(t *testing.T) {
+	profile := NewProfile("test-node", "cpu.example.com", 2, 4)
+
+	assert.Equal(t, "test-node", profile.nodeName)
+	assert.Equal(t, "cpu.example.com", profile.driverName)
+	assert.Equal(t, 2, profile.numNUMANodes)
+	assert.Equal(t, 4, profile.cpusPerNUMANode)
+}
+
+func TestEnumerateDevices(t *testing.T) {
+	const cpusPerNUMA = 4
+	profile := NewProfile("test-node", "cpu.example.com", 3, cpusPerNUMA)
+	wantKey := profile.CapacityKey()
+
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	require.Contains(t, resources.Pools, "test-node")
+	pool := resources.Pools["test-node"]
+	require.Len(t, pool.Slices, 1)
+	devices := pool.Slices[0].Devices
+	require.Len(t, devices, 3)
+
+	wantCPU := *resource.NewQuantity(int64(cpusPerNUMA), resource.DecimalSI)
+	for i, device := range devices {
+		assert.Equal(t, fmt.Sprintf("numa-%d", i), device.Name)
+		assert.NotNil(t, device.AllowMultipleAllocations)
+		assert.True(t, *device.AllowMultipleAllocations)
+
+		numaID := device.Attributes["numaNodeID"]
+		require.NotNil(t, numaID.IntValue)
+		assert.Equal(t, int64(i), *numaID.IntValue)
+
+		cap, ok := device.Capacity[wantKey]
+		require.True(t, ok, "device %q missing %q capacity entry", device.Name, wantKey)
+		assert.Equal(t, 0, cap.Value.Cmp(wantCPU))
+
+		require.Len(t, device.NodeAllocatableResourceMappings, 1)
+		cpuMapping, ok := device.NodeAllocatableResourceMappings[corev1.ResourceCPU]
+		require.True(t, ok)
+		require.NotNil(t, cpuMapping.CapacityKey)
+		assert.Equal(t, wantKey, *cpuMapping.CapacityKey)
+	}
+}
+
+func TestApplyConfig(t *testing.T) {
+	profile := NewProfile("test-node", "cpu.example.com", 2, 4)
+	results := []*resourceapi.DeviceRequestAllocationResult{{
+		Device: "numa-0",
+		ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+			profile.CapacityKey(): resource.MustParse("2"),
+		},
+	}}
+
+	edits, err := profile.ApplyConfig(nil, results)
+	require.NoError(t, err)
+	require.Contains(t, edits, "numa-0")
+	assert.ElementsMatch(t,
+		[]string{"CPU_DEVICE_0=numa-0", "CPU_DEVICE_0_CONSUMED_CPU=2"},
+		edits["numa-0"].Env,
+	)
+}

--- a/internal/profiles/helpers/uid_tool.go
+++ b/internal/profiles/helpers/uid_tool.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import "fmt"
+
+// GetCDIDeviceID returns the per-claim identifier for an allocated device. For
+// a share of a consumable-capacity device the ShareID is appended so that
+// multiple allocations of the same device map to distinct CDI devices; an
+// exclusively allocated device (nil ShareID) uses its name unchanged.
+func GetCDIDeviceID(device string, shareId *string) string {
+	if shareId != nil {
+		return fmt.Sprintf("%s-%s", device, *shareId)
+	}
+	return device
+}

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -34,8 +35,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -54,9 +57,20 @@ var restMapper meta.RESTMapper
 // driverPodSelector finds kubelet plugin Pods within an installed driver's release namespace.
 const driverPodSelector = "app.kubernetes.io/component=kubeletplugin"
 
-// defaultDeviceClassName is the driver name baked into demo manifests and
-// webhook testdata; deployManifest substitutes it for the per-test driver name.
-const defaultDeviceClassName = "gpu.example.com"
+// defaultGPUDeviceClassName is the driver name baked into demo manifests
+// and webhook testdata; deployManifest substitutes it for the per-test
+// driver name, and the webhook tests pin their installed driver to it so
+// their static testdata stays valid.
+const defaultGPUDeviceClassName = "gpu.example.com"
+
+// defaultCPUDeviceClassName is the driver name baked into demo manifests
+// using the cpu profile; deployManifest substitutes it for the per-test
+// driver name.
+const defaultCPUDeviceClassName = "cpu.example.com"
+
+// defaultDeviceClassNames are the driver names baked into demo manifests as
+// placeholders; deployManifest substitutes each for the per-test driver name.
+var defaultDeviceClassNames = []string{defaultGPUDeviceClassName, defaultCPUDeviceClassName}
 
 // defaultExtendedResourceName is the extended resource name baked into demo
 // manifests; deployManifest substitutes it when ExtendedResourceName is set.
@@ -108,7 +122,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 // deployManifest reads a demo manifest file, substitutes per-test driver
 // identifiers, creates the resulting objects, and registers cleanup and
 // failure diagnostics via DeferCleanup. Substitution rules:
-//   - "gpu.example.com" -> drv.DriverName (always applied)
+//   - any name in defaultDeviceClassNames -> drv.DriverName (always applied)
 //   - "example.com/gpu" -> drv.ExtendedResourceName (only when set)
 func deployManifest(ctx context.Context, namespace, manifestFile string, drv installedDriver) {
 	GinkgoHelper()
@@ -135,14 +149,19 @@ func deployManifest(ctx context.Context, namespace, manifestFile string, drv ins
 // with the per-test driver name and (when set) extended resource name.
 func substituteDriverIdentifiers(raw string, drv installedDriver) string {
 	GinkgoHelper()
-	out := strings.ReplaceAll(raw, defaultDeviceClassName, drv.DriverName)
+	out := raw
+	for _, placeholder := range defaultDeviceClassNames {
+		out = strings.ReplaceAll(out, placeholder, drv.DriverName)
+	}
 	if drv.ExtendedResourceName != "" {
 		out = strings.ReplaceAll(out, defaultExtendedResourceName, drv.ExtendedResourceName)
 	}
 	// Guard against demo manifests that drift from convention.
-	Expect(out).NotTo(ContainSubstring(defaultDeviceClassName),
-		"Manifest still references %q after substitution; deployManifest must replace every occurrence",
-		defaultDeviceClassName)
+	for _, placeholder := range defaultDeviceClassNames {
+		Expect(out).NotTo(ContainSubstring(placeholder),
+			"Manifest still references %q after substitution; deployManifest must replace every occurrence",
+			placeholder)
+	}
 	return out
 }
 
@@ -453,6 +472,103 @@ func verifyExtendedResourceClaimStatus(ctx context.Context, namespace, podName, 
 		fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s has extendedResourceClaimStatus mapping %s -> %s\n",
 			namespace, podName, containerName, expectedResourceName, matched.RequestName)
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}
+
+// verifyNodeAllocatableResourceClaimStatus verifies that the pod's
+// nodeAllocatableResourceClaimStatuses contains the expected per-resource
+// quantities for the (template-generated) ResourceClaim of podLocalClaimName.
+func verifyNodeAllocatableResourceClaimStatus(ctx context.Context, namespace, podName, podLocalClaimName, containerName string, expectedResources v1.ResourceList) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(),
+			"Failed to get pod %s/%s", namespace, podName)
+
+		rcsIdx := slices.IndexFunc(pod.Status.ResourceClaimStatuses, func(s v1.PodResourceClaimStatus) bool {
+			return s.Name == podLocalClaimName && s.ResourceClaimName != nil
+		})
+		g.Expect(rcsIdx).NotTo(Equal(-1),
+			"Pod %s/%s has no resourceClaimStatuses entry for pod-local claim %q; status: %+v",
+			namespace, podName, podLocalClaimName, pod.Status.ResourceClaimStatuses)
+		generatedClaimName := *pod.Status.ResourceClaimStatuses[rcsIdx].ResourceClaimName
+
+		statusIdx := slices.IndexFunc(pod.Status.NodeAllocatableResourceClaimStatuses, func(s v1.NodeAllocatableResourceClaimStatus) bool {
+			return s.ResourceClaimName == generatedClaimName
+		})
+		g.Expect(statusIdx).NotTo(Equal(-1),
+			"Pod %s/%s has no nodeAllocatableResourceClaimStatuses entry for claim %q; status: %+v",
+			namespace, podName, generatedClaimName, pod.Status.NodeAllocatableResourceClaimStatuses)
+		matched := &pod.Status.NodeAllocatableResourceClaimStatuses[statusIdx]
+
+		g.Expect(matched.Containers).To(ContainElement(containerName),
+			"Pod %s/%s nodeAllocatableResourceClaimStatuses entry for claim %q does not list container %q (got %v)",
+			namespace, podName, generatedClaimName, containerName, matched.Containers)
+
+		for resourceName, expected := range expectedResources {
+			actual, ok := matched.Resources[resourceName]
+			g.Expect(ok).To(BeTrue(),
+				"Pod %s/%s nodeAllocatableResourceClaimStatuses entry for claim %q has no %s resource: %+v",
+				namespace, podName, generatedClaimName, resourceName, matched.Resources)
+			g.Expect(actual.Cmp(expected)).To(BeZero(),
+				"Pod %s/%s claim %q resource %s: got %s, want %s",
+				namespace, podName, generatedClaimName, resourceName, actual.String(), expected.String())
+		}
+
+		fmt.Fprintf(GinkgoWriter, "Pod %s/%s claim %q has nodeAllocatableResourceClaimStatus %+v for container %s\n",
+			namespace, podName, generatedClaimName, matched.Resources, containerName)
+	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}
+
+// expectedMapping describes the asserted shape of a single
+// NodeAllocatableResourceMapping. Exactly one of AllocationMultiplier and
+// CapacityKey should be set; whichever is set is what the helper asserts.
+type expectedMapping struct {
+	AllocationMultiplier *resource.Quantity
+	CapacityKey          *resourceapi.QualifiedName
+}
+
+// waitForResourceSlicesWithNodeAllocatableMappings waits until every device
+// published by driverName carries NodeAllocatableResourceMappings matching
+// expected. Closes the race between driver install and ResourceSlice publication.
+func waitForResourceSlicesWithNodeAllocatableMappings(ctx context.Context, driverName string, expected map[v1.ResourceName]expectedMapping) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		slices, err := clientset.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
+			FieldSelector: "spec.driver=" + driverName,
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to list ResourceSlices")
+		g.Expect(slices.Items).NotTo(BeEmpty(),
+			"no ResourceSlices yet published for driver %q", driverName)
+
+		var matched int
+		for _, slice := range slices.Items {
+			for _, device := range slice.Spec.Devices {
+				mappings := device.NodeAllocatableResourceMappings
+				g.Expect(mappings).NotTo(BeNil(),
+					"device %q in slice %q has no NodeAllocatableResourceMappings", device.Name, slice.Name)
+
+				for resourceName, exp := range expected {
+					m, ok := mappings[resourceName]
+					g.Expect(ok).To(BeTrue(), "device %q missing %s mapping", device.Name, resourceName)
+					switch {
+					case exp.AllocationMultiplier != nil:
+						g.Expect(m.AllocationMultiplier).NotTo(BeNil(), "device %q %s mapping has no AllocationMultiplier", device.Name, resourceName)
+						g.Expect(m.AllocationMultiplier.Cmp(*exp.AllocationMultiplier)).To(BeZero(),
+							"device %q %s multiplier = %s, want %s", device.Name, resourceName, m.AllocationMultiplier.String(), exp.AllocationMultiplier.String())
+					case exp.CapacityKey != nil:
+						g.Expect(m.CapacityKey).NotTo(BeNil(), "device %q %s mapping has no CapacityKey", device.Name, resourceName)
+						g.Expect(*m.CapacityKey).To(Equal(*exp.CapacityKey),
+							"device %q %s capacityKey = %q, want %q", device.Name, resourceName, *m.CapacityKey, *exp.CapacityKey)
+					default:
+						Fail(fmt.Sprintf("expectedMapping for %s must set either AllocationMultiplier or CapacityKey", resourceName))
+					}
+				}
+				matched++
+			}
+		}
+		g.Expect(matched).To(BeNumerically(">", 0),
+			"no devices for driver %q advertise NodeAllocatableResourceMappings yet", driverName)
+	}, "60s", "2s").Should(Succeed())
 }
 
 // claimNewGPU verifies that a GPU is unclaimed and adds it to observedGPUs.

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -520,6 +520,51 @@ func verifyNodeAllocatableResourceClaimStatus(ctx context.Context, namespace, po
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 }
 
+// deviceShare is one allocation result's device name and ShareID.
+type deviceShare struct {
+	device  string
+	shareID string
+}
+
+// getClaimDeviceShares returns the device name and ShareID for every allocation
+// result of the (template-generated) ResourceClaim referenced by
+// podLocalClaimName. ShareID is the empty string when an allocation has none.
+// It retries until the claim exists and is allocated.
+func getClaimDeviceShares(ctx context.Context, namespace, podName, podLocalClaimName string) []deviceShare {
+	GinkgoHelper()
+	var shares []deviceShare
+	Eventually(func(g Gomega) {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s/%s", namespace, podName)
+
+		rcsIdx := slices.IndexFunc(pod.Status.ResourceClaimStatuses, func(s v1.PodResourceClaimStatus) bool {
+			return s.Name == podLocalClaimName && s.ResourceClaimName != nil
+		})
+		g.Expect(rcsIdx).NotTo(Equal(-1),
+			"Pod %s/%s has no resourceClaimStatuses entry for pod-local claim %q; status: %+v",
+			namespace, podName, podLocalClaimName, pod.Status.ResourceClaimStatuses)
+		claimName := *pod.Status.ResourceClaimStatuses[rcsIdx].ResourceClaimName
+
+		claim, err := clientset.ResourceV1().ResourceClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to get ResourceClaim %s/%s", namespace, claimName)
+		g.Expect(claim.Status.Allocation).NotTo(BeNil(),
+			"ResourceClaim %s/%s is not yet allocated", namespace, claimName)
+		g.Expect(claim.Status.Allocation.Devices.Results).NotTo(BeEmpty(),
+			"ResourceClaim %s/%s has no allocated devices", namespace, claimName)
+
+		results := claim.Status.Allocation.Devices.Results
+		shares = make([]deviceShare, 0, len(results))
+		for _, result := range results {
+			share := deviceShare{device: result.Device}
+			if result.ShareID != nil {
+				share.shareID = string(*result.ShareID)
+			}
+			shares = append(shares, share)
+		}
+	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+	return shares
+}
+
 // expectedMapping describes the asserted shape of a single
 // NodeAllocatableResourceMapping. Exactly one of AllocationMultiplier and
 // CapacityKey should be set; whichever is set is what the helper asserts.

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -56,9 +58,20 @@ var restMapper meta.RESTMapper
 // driverPodSelector finds kubelet plugin Pods within an installed driver's release namespace.
 const driverPodSelector = "app.kubernetes.io/component=kubeletplugin"
 
-// defaultDeviceClassName is the driver name baked into demo manifests and
-// webhook testdata; deployManifest substitutes it for the per-test driver name.
-const defaultDeviceClassName = "gpu.example.com"
+// defaultGPUDeviceClassName is the driver name baked into demo manifests
+// and webhook testdata; deployManifest substitutes it for the per-test
+// driver name, and the webhook tests pin their installed driver to it so
+// their static testdata stays valid.
+const defaultGPUDeviceClassName = "gpu.example.com"
+
+// defaultCPUDeviceClassName is the driver name baked into demo manifests
+// using the cpu profile; deployManifest substitutes it for the per-test
+// driver name.
+const defaultCPUDeviceClassName = "cpu.example.com"
+
+// defaultDeviceClassNames are the driver names baked into demo manifests as
+// placeholders; deployManifest substitutes each for the per-test driver name.
+var defaultDeviceClassNames = []string{defaultGPUDeviceClassName, defaultCPUDeviceClassName}
 
 // defaultExtendedResourceName is the extended resource name baked into demo
 // manifests; deployManifest substitutes it when ExtendedResourceName is set.
@@ -110,7 +123,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 // deployManifest reads a demo manifest file, substitutes per-test driver
 // identifiers, creates the resulting objects, and registers cleanup and
 // failure diagnostics via DeferCleanup. Substitution rules:
-//   - "gpu.example.com" -> drv.DriverName (always applied)
+//   - any name in defaultDeviceClassNames -> drv.DriverName (always applied)
 //   - "example.com/gpu" -> drv.ExtendedResourceName (only when set)
 func deployManifest(ctx context.Context, namespace, manifestFile string, drv installedDriver) {
 	GinkgoHelper()
@@ -137,14 +150,19 @@ func deployManifest(ctx context.Context, namespace, manifestFile string, drv ins
 // with the per-test driver name and (when set) extended resource name.
 func substituteDriverIdentifiers(raw string, drv installedDriver) string {
 	GinkgoHelper()
-	out := strings.ReplaceAll(raw, defaultDeviceClassName, drv.DriverName)
+	out := raw
+	for _, placeholder := range defaultDeviceClassNames {
+		out = strings.ReplaceAll(out, placeholder, drv.DriverName)
+	}
 	if drv.ExtendedResourceName != "" {
 		out = strings.ReplaceAll(out, defaultExtendedResourceName, drv.ExtendedResourceName)
 	}
 	// Guard against demo manifests that drift from convention.
-	Expect(out).NotTo(ContainSubstring(defaultDeviceClassName),
-		"Manifest still references %q after substitution; deployManifest must replace every occurrence",
-		defaultDeviceClassName)
+	for _, placeholder := range defaultDeviceClassNames {
+		Expect(out).NotTo(ContainSubstring(placeholder),
+			"Manifest still references %q after substitution; deployManifest must replace every occurrence",
+			placeholder)
+	}
 	return out
 }
 
@@ -455,6 +473,103 @@ func verifyExtendedResourceClaimStatus(ctx context.Context, namespace, podName, 
 		fmt.Fprintf(GinkgoWriter, "Pod %s/%s, container %s has extendedResourceClaimStatus mapping %s -> %s\n",
 			namespace, podName, containerName, expectedResourceName, matched.RequestName)
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}
+
+// verifyNodeAllocatableResourceClaimStatus verifies that the pod's
+// nodeAllocatableResourceClaimStatuses contains the expected per-resource
+// quantities for the (template-generated) ResourceClaim of podLocalClaimName.
+func verifyNodeAllocatableResourceClaimStatus(ctx context.Context, namespace, podName, podLocalClaimName, containerName string, expectedResources v1.ResourceList) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(),
+			"Failed to get pod %s/%s", namespace, podName)
+
+		rcsIdx := slices.IndexFunc(pod.Status.ResourceClaimStatuses, func(s v1.PodResourceClaimStatus) bool {
+			return s.Name == podLocalClaimName && s.ResourceClaimName != nil
+		})
+		g.Expect(rcsIdx).NotTo(Equal(-1),
+			"Pod %s/%s has no resourceClaimStatuses entry for pod-local claim %q; status: %+v",
+			namespace, podName, podLocalClaimName, pod.Status.ResourceClaimStatuses)
+		generatedClaimName := *pod.Status.ResourceClaimStatuses[rcsIdx].ResourceClaimName
+
+		statusIdx := slices.IndexFunc(pod.Status.NodeAllocatableResourceClaimStatuses, func(s v1.NodeAllocatableResourceClaimStatus) bool {
+			return s.ResourceClaimName == generatedClaimName
+		})
+		g.Expect(statusIdx).NotTo(Equal(-1),
+			"Pod %s/%s has no nodeAllocatableResourceClaimStatuses entry for claim %q; status: %+v",
+			namespace, podName, generatedClaimName, pod.Status.NodeAllocatableResourceClaimStatuses)
+		matched := &pod.Status.NodeAllocatableResourceClaimStatuses[statusIdx]
+
+		g.Expect(matched.Containers).To(ContainElement(containerName),
+			"Pod %s/%s nodeAllocatableResourceClaimStatuses entry for claim %q does not list container %q (got %v)",
+			namespace, podName, generatedClaimName, containerName, matched.Containers)
+
+		for resourceName, expected := range expectedResources {
+			actual, ok := matched.Resources[resourceName]
+			g.Expect(ok).To(BeTrue(),
+				"Pod %s/%s nodeAllocatableResourceClaimStatuses entry for claim %q has no %s resource: %+v",
+				namespace, podName, generatedClaimName, resourceName, matched.Resources)
+			g.Expect(actual.Cmp(expected)).To(BeZero(),
+				"Pod %s/%s claim %q resource %s: got %s, want %s",
+				namespace, podName, generatedClaimName, resourceName, actual.String(), expected.String())
+		}
+
+		fmt.Fprintf(GinkgoWriter, "Pod %s/%s claim %q has nodeAllocatableResourceClaimStatus %+v for container %s\n",
+			namespace, podName, generatedClaimName, matched.Resources, containerName)
+	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}
+
+// expectedMapping describes the asserted shape of a single
+// NodeAllocatableResourceMapping. Exactly one of AllocationMultiplier and
+// CapacityKey should be set; whichever is set is what the helper asserts.
+type expectedMapping struct {
+	AllocationMultiplier *resource.Quantity
+	CapacityKey          *resourceapi.QualifiedName
+}
+
+// waitForResourceSlicesWithNodeAllocatableMappings waits until every device
+// published by driverName carries NodeAllocatableResourceMappings matching
+// expected. Closes the race between driver install and ResourceSlice publication.
+func waitForResourceSlicesWithNodeAllocatableMappings(ctx context.Context, driverName string, expected map[v1.ResourceName]expectedMapping) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		slices, err := clientset.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
+			FieldSelector: "spec.driver=" + driverName,
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to list ResourceSlices")
+		g.Expect(slices.Items).NotTo(BeEmpty(),
+			"no ResourceSlices yet published for driver %q", driverName)
+
+		var matched int
+		for _, slice := range slices.Items {
+			for _, device := range slice.Spec.Devices {
+				mappings := device.NodeAllocatableResourceMappings
+				g.Expect(mappings).NotTo(BeNil(),
+					"device %q in slice %q has no NodeAllocatableResourceMappings", device.Name, slice.Name)
+
+				for resourceName, exp := range expected {
+					m, ok := mappings[resourceName]
+					g.Expect(ok).To(BeTrue(), "device %q missing %s mapping", device.Name, resourceName)
+					switch {
+					case exp.AllocationMultiplier != nil:
+						g.Expect(m.AllocationMultiplier).NotTo(BeNil(), "device %q %s mapping has no AllocationMultiplier", device.Name, resourceName)
+						g.Expect(m.AllocationMultiplier.Cmp(*exp.AllocationMultiplier)).To(BeZero(),
+							"device %q %s multiplier = %s, want %s", device.Name, resourceName, m.AllocationMultiplier.String(), exp.AllocationMultiplier.String())
+					case exp.CapacityKey != nil:
+						g.Expect(m.CapacityKey).NotTo(BeNil(), "device %q %s mapping has no CapacityKey", device.Name, resourceName)
+						g.Expect(*m.CapacityKey).To(Equal(*exp.CapacityKey),
+							"device %q %s capacityKey = %q, want %q", device.Name, resourceName, *m.CapacityKey, *exp.CapacityKey)
+					default:
+						Fail(fmt.Sprintf("expectedMapping for %s must set either AllocationMultiplier or CapacityKey", resourceName))
+					}
+				}
+				matched++
+			}
+		}
+		g.Expect(matched).To(BeNumerically(">", 0),
+			"no devices for driver %q advertise NodeAllocatableResourceMappings yet", driverName)
+	}, "60s", "2s").Should(Succeed())
 }
 
 // claimNewGPU verifies that a GPU is unclaimed and adds it to observedGPUs.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -270,12 +271,38 @@ var _ = Describe("Test GPU allocation", func() {
 		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 	})
 
+	It("should account for native CPU resources via DRA", func(ctx SpecContext) {
+		drv := installDriver(ctx, DriverConfig{
+			NumDevices: 1, // one fake NUMA node
+			ExtraValues: map[string]string{
+				"deviceProfile":                     "cpu",
+				"kubeletPlugin.cpu.cpusPerNUMANode": "4",
+			},
+		})
+		// The driver derives its capacity key from its own name, so each
+		// per-test install advertises a distinct key.
+		cpuKey := resourcev1.QualifiedName(drv.DriverName + "/cpu")
+		waitForResourceSlicesWithNodeAllocatableMappings(ctx, drv.DriverName,
+			map[corev1.ResourceName]expectedMapping{
+				corev1.ResourceCPU: {CapacityKey: &cpuKey},
+			},
+		)
+
+		namespace := "native-resource-request"
+		deployManifest(ctx, namespace, "native-resource-request.yaml", drv)
+		checkPodsReadyAndRunning(ctx, namespace, []string{"pod0"})
+
+		verifyNodeAllocatableResourceClaimStatus(ctx, namespace, "pod0", "cpus", "ctr0",
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+		)
+	})
+
 	// Webhook tests share one driver pinned to "gpu.example.com" so their
 	// static testdata stays valid; Ordered+Serial avoids concurrent upgrades.
 	Context("Webhooks", Ordered, Serial, func() {
 		BeforeAll(func(ctx SpecContext) {
 			installDriver(ctx, DriverConfig{
-				DriverName:     defaultDeviceClassName,
+				DriverName:     defaultGPUDeviceClassName,
 				WebhookEnabled: true,
 			})
 		})
@@ -307,13 +334,13 @@ var _ = Describe("Test GPU allocation", func() {
 					Devices: resourcev1.DeviceClaim{
 						Requests: []resourcev1.DeviceRequest{{
 							Name:    "ts-gpu",
-							Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultDeviceClassName},
+							Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultGPUDeviceClassName},
 						}},
 						Config: []resourcev1.DeviceClaimConfiguration{{
 							Requests: []string{"ts-gpu"},
 							DeviceConfiguration: resourcev1.DeviceConfiguration{
 								Opaque: &resourcev1.OpaqueDeviceConfiguration{
-									Driver:     defaultDeviceClassName,
+									Driver:     defaultGPUDeviceClassName,
 									Parameters: invalidGpuConfig(),
 								},
 							},
@@ -334,13 +361,13 @@ var _ = Describe("Test GPU allocation", func() {
 					Devices: resourcev1beta1.DeviceClaim{
 						Requests: []resourcev1beta1.DeviceRequest{{
 							Name:            "ts-gpu",
-							DeviceClassName: defaultDeviceClassName,
+							DeviceClassName: defaultGPUDeviceClassName,
 						}},
 						Config: []resourcev1beta1.DeviceClaimConfiguration{{
 							Requests: []string{"ts-gpu"},
 							DeviceConfiguration: resourcev1beta1.DeviceConfiguration{
 								Opaque: &resourcev1beta1.OpaqueDeviceConfiguration{
-									Driver:     defaultDeviceClassName,
+									Driver:     defaultGPUDeviceClassName,
 									Parameters: invalidGpuConfig(),
 								},
 							},
@@ -362,13 +389,13 @@ var _ = Describe("Test GPU allocation", func() {
 						Devices: resourcev1.DeviceClaim{
 							Requests: []resourcev1.DeviceRequest{{
 								Name:    "ts-gpu",
-								Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultDeviceClassName},
+								Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultGPUDeviceClassName},
 							}},
 							Config: []resourcev1.DeviceClaimConfiguration{{
 								Requests: []string{"ts-gpu"},
 								DeviceConfiguration: resourcev1.DeviceConfiguration{
 									Opaque: &resourcev1.OpaqueDeviceConfiguration{
-										Driver:     defaultDeviceClassName,
+										Driver:     defaultGPUDeviceClassName,
 										Parameters: invalidGpuConfig(),
 									},
 								},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -274,30 +274,46 @@ var _ = Describe("Test GPU allocation", func() {
 		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 	})
 
-	It("should account for native CPU resources via DRA", func(ctx SpecContext) {
-		drv := installDriver(ctx, DriverConfig{
-			NumDevices: 1, // one fake NUMA node
+	// Run Serial with a single cpu driver: the cpu pod's capacity is charged
+	// against the node's allocatable cpu (so it shouldn't compete with the
+	// parallel gpu specs), and the kubelet attributes that node resource to
+	// only one cpu driver at a time.
+	It("should account for native CPU resources and share a NUMA device across requests", Serial, func(ctx SpecContext) {
+		cpuDriver := installDriver(ctx, DriverConfig{
 			ExtraValues: map[string]string{
 				"deviceProfile":                     "cpu",
-				"kubeletPlugin.cpu.cpusPerNUMANode": "4",
+				"kubeletPlugin.cpu.numaNodes":       "1",
+				"kubeletPlugin.cpu.cpusPerNUMANode": "2",
 			},
 		})
-		// The driver derives its capacity key from its own name, so each
-		// per-test install advertises a distinct key.
-		cpuKey := resourcev1.QualifiedName(drv.DriverName + "/cpu")
-		waitForResourceSlicesWithNodeAllocatableMappings(ctx, drv.DriverName,
+		cpuKey := resourcev1.QualifiedName(cpuDriver.DriverName + "/cpu")
+		waitForResourceSlicesWithNodeAllocatableMappings(ctx, cpuDriver.DriverName,
 			map[corev1.ResourceName]expectedMapping{
 				corev1.ResourceCPU: {CapacityKey: &cpuKey},
 			},
 		)
 
+		// The claim makes two 1-CPU requests; with one NUMA node both resolve to
+		// the same device, so the driver must keep the two shares distinct (via
+		// ShareID) to prepare them. The pod only runs if that works.
 		namespace := "native-resource-request"
-		deployManifest(ctx, namespace, "native-resource-request.yaml", drv)
+		deployManifest(ctx, namespace, "native-resource-request.yaml", cpuDriver)
 		checkPodsReadyAndRunning(ctx, namespace, []string{"pod0"})
 
+		// The scheduler debits both requests (2 CPUs total) from the node's
+		// allocatable budget for the pod.
 		verifyNodeAllocatableResourceClaimStatus(ctx, namespace, "pod0", "cpus", "ctr0",
 			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
 		)
+
+		// Both requests resolve to the same device but must carry distinct,
+		// non-empty ShareIDs so the two shares are tracked separately.
+		shares := getClaimDeviceShares(ctx, namespace, "pod0", "cpus")
+		Expect(shares).To(HaveLen(2), "claim should have two allocation results")
+		Expect(shares[0].device).To(Equal(shares[1].device), "both requests should share the same NUMA device")
+		Expect(shares[0].shareID).NotTo(BeEmpty(), "first allocation should have a ShareID")
+		Expect(shares[1].shareID).NotTo(BeEmpty(), "second allocation should have a ShareID")
+		Expect(shares[0].shareID).NotTo(Equal(shares[1].shareID), "shared allocations must have distinct ShareIDs")
 	})
 
 	// Webhook tests share one driver pinned to "gpu.example.com" so their

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -273,12 +274,38 @@ var _ = Describe("Test GPU allocation", func() {
 		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 	})
 
+	It("should account for native CPU resources via DRA", func(ctx SpecContext) {
+		drv := installDriver(ctx, DriverConfig{
+			NumDevices: 1, // one fake NUMA node
+			ExtraValues: map[string]string{
+				"deviceProfile":                     "cpu",
+				"kubeletPlugin.cpu.cpusPerNUMANode": "4",
+			},
+		})
+		// The driver derives its capacity key from its own name, so each
+		// per-test install advertises a distinct key.
+		cpuKey := resourcev1.QualifiedName(drv.DriverName + "/cpu")
+		waitForResourceSlicesWithNodeAllocatableMappings(ctx, drv.DriverName,
+			map[corev1.ResourceName]expectedMapping{
+				corev1.ResourceCPU: {CapacityKey: &cpuKey},
+			},
+		)
+
+		namespace := "native-resource-request"
+		deployManifest(ctx, namespace, "native-resource-request.yaml", drv)
+		checkPodsReadyAndRunning(ctx, namespace, []string{"pod0"})
+
+		verifyNodeAllocatableResourceClaimStatus(ctx, namespace, "pod0", "cpus", "ctr0",
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+		)
+	})
+
 	// Webhook tests share one driver pinned to "gpu.example.com" so their
 	// static testdata stays valid; Ordered+Serial avoids concurrent upgrades.
 	Context("Webhooks", Ordered, Serial, func() {
 		BeforeAll(func(ctx SpecContext) {
 			installDriver(ctx, DriverConfig{
-				DriverName:     defaultDeviceClassName,
+				DriverName:     defaultGPUDeviceClassName,
 				WebhookEnabled: true,
 			})
 		})
@@ -310,13 +337,13 @@ var _ = Describe("Test GPU allocation", func() {
 					Devices: resourcev1.DeviceClaim{
 						Requests: []resourcev1.DeviceRequest{{
 							Name:    "ts-gpu",
-							Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultDeviceClassName},
+							Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultGPUDeviceClassName},
 						}},
 						Config: []resourcev1.DeviceClaimConfiguration{{
 							Requests: []string{"ts-gpu"},
 							DeviceConfiguration: resourcev1.DeviceConfiguration{
 								Opaque: &resourcev1.OpaqueDeviceConfiguration{
-									Driver:     defaultDeviceClassName,
+									Driver:     defaultGPUDeviceClassName,
 									Parameters: invalidGpuConfig(),
 								},
 							},
@@ -337,13 +364,13 @@ var _ = Describe("Test GPU allocation", func() {
 					Devices: resourcev1beta1.DeviceClaim{
 						Requests: []resourcev1beta1.DeviceRequest{{
 							Name:            "ts-gpu",
-							DeviceClassName: defaultDeviceClassName,
+							DeviceClassName: defaultGPUDeviceClassName,
 						}},
 						Config: []resourcev1beta1.DeviceClaimConfiguration{{
 							Requests: []string{"ts-gpu"},
 							DeviceConfiguration: resourcev1beta1.DeviceConfiguration{
 								Opaque: &resourcev1beta1.OpaqueDeviceConfiguration{
-									Driver:     defaultDeviceClassName,
+									Driver:     defaultGPUDeviceClassName,
 									Parameters: invalidGpuConfig(),
 								},
 							},
@@ -365,13 +392,13 @@ var _ = Describe("Test GPU allocation", func() {
 						Devices: resourcev1.DeviceClaim{
 							Requests: []resourcev1.DeviceRequest{{
 								Name:    "ts-gpu",
-								Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultDeviceClassName},
+								Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: defaultGPUDeviceClassName},
 							}},
 							Config: []resourcev1.DeviceClaimConfiguration{{
 								Requests: []string{"ts-gpu"},
 								DeviceConfiguration: resourcev1.DeviceConfiguration{
 									Opaque: &resourcev1.OpaqueDeviceConfiguration{
-										Driver:     defaultDeviceClassName,
+										Driver:     defaultGPUDeviceClassName,
 										Parameters: invalidGpuConfig(),
 									},
 								},


### PR DESCRIPTION
Fixes #184 

Adds a new `cpu` device profile that demonstrates the DRA native (node-allocatable) resource accounting feature ([KEP-5517](https://github.com/kubernetes/enhancements/issues/5517), Alpha in 1.36 behind `DRANodeAllocatableResources`), modeled after how a real DRA CPU driver ([dra-driver-cpu](https://github.com/kubernetes-sigs/dra-driver-cpu)) represents devices.

The driver publishes one DRA device per fake NUMA node, each one exposing its CPUs as consumable capacity. Every device carries `NodeAllocatableResourceMappings` with `CapacityKey` pointing at that capacity pool, so kube-scheduler debits the consumed CPU count from the node's standard allocatable budget every time a claim is satisfied. This prevents oversubscription when CPUs are managed through DRA alongside the classic pod-spec request API.

Because `AllowMultipleAllocations: true` is set on each NUMA device, multiple pods can share a NUMA node by claiming different amounts of capacity, mirroring real-world CPU pooling.

The `cpu` profile does not support opaque per-claim configuration in this iteration (any `parameters` block on a CPU `ResourceClaim` is rejected by the webhook). There's no `CpuConfig` API type defined yet because no configurable knob has surfaced as needed for the demo. The obvious candidates (exclusive vs shared, SMT-sibling preference, etc.) belong to follow-up examples that exercise specific behaviors. Adding opaque config later is a straightforward additive change: define the type under `api/example.com/resource/cpu/v1alpha1`, register it in `SchemeBuilder()`, and handle the typed config in `Validate` / `ApplyConfig`.

### Changes

- `internal/profiles/cpu/cpu.go` (new): publishes per-NUMA `Device`s with `AllowMultipleAllocations: true`, `Capacity[<driverName>/cpu]`, and `NodeAllocatableResourceMappings[cpu].CapacityKey`. The capacity key is derived from the driver name at runtime so multiple driver releases can coexist without colliding.
- `cmd/dra-example-kubeletplugin/main.go` and `cmd/dra-example-webhook/main.go`: register the `cpu` profile, plumb a new `--cpus-per-numa-node` flag.
- Helm chart: `cpu` added to the `deviceProfile` enum; new `kubeletPlugin.cpu.cpusPerNUMANode` value wired through.
- `demo/scripts/kind-cluster-config.yaml`: enables both `DRANodeAllocatableResources` and `DRAConsumableCapacity` feature gates (the latter is needed for `AllowMultipleAllocations`, `Device.Capacity`, and claim-side `capacity.requests`).
- `demo/native-resource-request.yaml`: the example. Pod claims `2` units of `<driver>/cpu` capacity via a `ResourceClaimTemplate`.
- `test/e2e/e2e_setup_test.go`: extend `substituteDriverIdentifiers` to also rewrite `cpu.example.com`; add `verifyNodeAllocatableResourceClaimStatus` and `waitForResourceSlicesWithNodeAllocatableMappings` (the latter accepts an `expectedMapping` that handles both `AllocationMultiplier` and `CapacityKey` shapes).
- `test/e2e/e2e_test.go`: new spec that installs the cpu profile, verifies the published mappings, deploys the demo, and asserts `pod.status.nodeAllocatableResourceClaimStatuses`.
- Unit tests for the cpu profile covering device naming, NUMA attributes, `AllowMultipleAllocations`, capacity, `CapacityKey` mapping shape, env-var injection, and config validation.