### PR TITLE
chore: ignore config telemetry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 
 driver_image.tar
 *.tgz
+
+# Ignore config telemetry files
+.config/


### PR DESCRIPTION
Add .config/ directory to .gitignore to exclude configuration telemetry files from version control.