### PR TITLE
Test on Kubernetes 1.36.1

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
         sudo snap install kubectl --classic
     - name: install kind
       run: |
-        go install sigs.k8s.io/kind@v0.31.0
+        go install sigs.k8s.io/kind@v0.32.0
     - name: Setup e2e
       run: make setup-e2e
     - name: run e2e test

--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -36,7 +36,7 @@ SCRIPTS_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 
 # The kubernetes tag to build the kind cluster from
 # From ${KIND_K8S_REPO}/tags
-: ${KIND_K8S_TAG:="v1.36.0"}
+: ${KIND_K8S_TAG:="v1.36.1"}
 
 # The name of the kind cluster to create
 : ${KIND_CLUSTER_NAME:="${DRIVER_NAME}-cluster"}

--- a/demo/scripts/kind-cluster-config.yaml
+++ b/demo/scripts/kind-cluster-config.yaml
@@ -7,6 +7,9 @@ featureGates:
   GangScheduling: true
   GenericWorkload: true
   DRAExtendedResource: true
+runtimeConfig:
+  resource.k8s.io/v1beta1: "true"
+  scheduling.k8s.io/v1alpha2: "true"
 containerdConfigPatches:
 # Enable CDI as described in
 # https://tags.cncf.io/container-device-interface#containerd-configuration
@@ -18,9 +21,6 @@ nodes:
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiServer:
-      extraArgs:
-        runtime-config: "resource.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha2=true"
     scheduler:
       extraArgs:
         v: "1"


### PR DESCRIPTION
A 1.36.1 pre-built kind node image is available which should save our CI from building a 1.36.0 image itself. A pre-built image is also required for systems with a container runtime other than Docker. The new kind images require the latest [kind v0.32.0 release](https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0).