### PR TITLE
Keep Go build cache for Docker builds

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -20,7 +20,9 @@ WORKDIR /build
 COPY . .
 
 RUN mkdir /artifacts
-RUN make PREFIX=/artifacts cmds
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    make PREFIX=/artifacts cmds
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
This saves from downloading and building every module dependency every time the build runs.

Rebuilding without any changes before:
```
[+] Building 42.4s (15/15) FINISHED                                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                       0.0s
 => => transferring dockerfile: 1.44kB                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                            0.4s
 => [internal] load metadata for docker.io/library/golang:1.26.2                                                                                                                           0.2s
 => [internal] load .dockerignore                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                            0.0s
 => [build 1/5] FROM docker.io/library/golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716                                                               0.0s
 => [stage-1 1/4] FROM docker.io/library/ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d                                                              0.0s
 => [internal] load build context                                                                                                                                                          0.6s
 => => transferring context: 2.13MB                                                                                                                                                        0.6s
 => CACHED [build 2/5] WORKDIR /build                                                                                                                                                      0.0s
 => [build 3/5] COPY . .                                                                                                                                                                   1.8s
 => [build 4/5] RUN mkdir /artifacts                                                                                                                                                       0.2s
 => [build 5/5] RUN make PREFIX=/artifacts cmds                                                                                                                                           38.9s
 => CACHED [stage-1 2/4] COPY --from=build /artifacts/dra-example-kubeletplugin /usr/bin/dra-example-kubeletplugin                                                                         0.0s 
 => CACHED [stage-1 3/4] COPY --from=build /artifacts/dra-example-controller    /usr/bin/dra-example-controller                                                                            0.0s 
 => CACHED [stage-1 4/4] COPY --from=build /artifacts/dra-example-webhook       /usr/bin/dra-example-webhook                                                                               0.0s 
 => exporting to image                                                                                                                                                                     0.0s 
 => => exporting layers                                                                                                                                                                    0.0s 
 => => writing image sha256:307cd58813e838d29eba8c62aa1def0a8392342c4ff456df1eab43bd61f7f7ae                                                                                               0.0s 
 => => naming to registry.k8s.io/dra-example-driver/dra-example-driver:v0.3.0                                                                                                              0.0s
```

After:
```
[+] Building 6.3s (15/15) FINISHED                                                                                                                                               docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                       0.0s
 => => transferring dockerfile: 1.54kB                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                            0.2s
 => [internal] load metadata for docker.io/library/golang:1.26.2                                                                                                                           0.2s
 => [internal] load .dockerignore                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                            0.0s
 => [build 1/5] FROM docker.io/library/golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716                                                               0.0s
 => [internal] load build context                                                                                                                                                          0.4s
 => => transferring context: 2.12MB                                                                                                                                                        0.4s
 => [stage-1 1/4] FROM docker.io/library/ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d                                                              0.0s
 => CACHED [build 2/5] WORKDIR /build                                                                                                                                                      0.0s
 => [build 3/5] COPY . .                                                                                                                                                                   1.8s
 => [build 4/5] RUN mkdir /artifacts                                                                                                                                                       0.2s
 => [build 5/5] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make PREFIX=/artifacts cmds                                              3.3s
 => CACHED [stage-1 2/4] COPY --from=build /artifacts/dra-example-kubeletplugin /usr/bin/dra-example-kubeletplugin                                                                         0.0s 
 => CACHED [stage-1 3/4] COPY --from=build /artifacts/dra-example-controller    /usr/bin/dra-example-controller                                                                            0.0s 
 => CACHED [stage-1 4/4] COPY --from=build /artifacts/dra-example-webhook       /usr/bin/dra-example-webhook                                                                               0.0s 
 => exporting to image                                                                                                                                                                     0.0s 
 => => exporting layers                                                                                                                                                                    0.0s 
 => => writing image sha256:2bdffe3ce001376d901181e2e5c0cf15a1f2181ee085cf73624298867bdab19b                                                                                               0.0s 
 => => naming to registry.k8s.io/dra-example-driver/dra-example-driver:v0.3.0                                                                                                              0.0s
```