### PR TITLE
Add example for prioritized alternatives

### DIFF
--- a/demo/examples/prioritized-alternatives/README.md
+++ b/demo/examples/prioritized-alternatives/README.md
@@ -1,0 +1,152 @@
+# Prioritized Alternatives Example
+
+## Overview
+
+This example demonstrates prioritized alternatives in device requests
+([KEP-4816](https://github.com/kubernetes/enhancements/issues/4816)). A single
+`DeviceRequest` lists several ways to satisfy itself in priority order via the
+`firstAvailable` field. The scheduler tries each subrequest in turn and
+allocates the first one that can be satisfied, letting a workload prefer a
+high-end device but still run on a less specialized one when the preferred
+options are unavailable.
+
+**Setup**: Two pods, each making a single `gpu` request that offers a prioritized
+list of alternatives (subrequests), not separate GPUs.
+
+- **pod0 (fallback)**: the first two subrequests carry a CEL selector that no
+  device can satisfy, so the request falls through to the third.
+- **pod1 (preference)**: both subrequests can be satisfied, so the scheduler
+  picks the higher-priority one.
+
+## GPU Allocation
+
+```mermaid
+graph LR
+    subgraph Pod0 [Pod 0: fallback]
+        C0(Container ctr0)
+    end
+    subgraph FA0 ["gpu (firstAvailable)"]
+        A1["1. bleeding-edge-gpu<br/>model == BLEEDING-EDGE-GPU<br/>(no match)"]
+        A2["2. huge-gpu<br/>memory >= 1Ti<br/>(no match)"]
+        A3["3. older-gpu<br/>any GPU"]
+        A1 --> A2 --> A3
+    end
+    C0 --> A1
+    A3 ==>|allocated| G0[[GPU]]
+
+    subgraph Pod1 [Pod 1: preference]
+        C1(Container ctr0)
+    end
+    subgraph FA1 ["gpu (firstAvailable)"]
+        B1["1. latest-gpu<br/>model == LATEST-GPU-MODEL<br/>(match)"]
+        B2["2. older-gpu<br/>any GPU"]
+        B1 --> B2
+    end
+    C1 --> B1
+    B1 ==>|allocated| G1[[GPU]]
+
+    style Pod0 stroke:#326ce5,stroke-width:2px
+    style Pod1 stroke:#326ce5,stroke-width:2px
+    style C0 fill:#d4edda,color:#000,stroke:#28a745,stroke-width:2px
+    style C1 fill:#d4edda,color:#000,stroke:#28a745,stroke-width:2px
+    style FA0 fill:#f8f9fa,color:#000,stroke:#6c757d,stroke-width:2px
+    style FA1 fill:#f8f9fa,color:#000,stroke:#6c757d,stroke-width:2px
+    style A1 fill:#e9ecef,color:#000,stroke:#adb5bd,stroke-width:2px
+    style A2 fill:#e9ecef,color:#000,stroke:#adb5bd,stroke-width:2px
+    style A3 fill:#9b59b6,color:#fff,stroke:#8e44ad,stroke-width:3px
+    style B1 fill:#9b59b6,color:#fff,stroke:#8e44ad,stroke-width:3px
+    style B2 fill:#e9ecef,color:#000,stroke:#adb5bd,stroke-width:2px
+    style G0 fill:#3498db,color:#fff,stroke:#2980b9,stroke-width:3px
+    style G1 fill:#3498db,color:#fff,stroke:#2980b9,stroke-width:3px
+```
+
+## How It Works
+
+Each subrequest is matched against the GPU devices that the example driver
+advertises. The driver
+([`internal/profiles/gpu/gpu.go`](../../../internal/profiles/gpu/gpu.go))
+publishes every GPU with a `model` attribute of `LATEST-GPU-MODEL` and a `memory`
+capacity of `80Gi`. The subrequests filter on those values using CEL selectors,
+and the scheduler uses the first subrequest that can be satisfied.
+
+**pod0 — fallback.** The first two selectors match no device, so `firstAvailable`
+falls through to `older-gpu`:
+
+| # | Subrequest | Selector | Devices matched | Result |
+| - | ---------- | -------- | --------------- | ------ |
+| 1 | `bleeding-edge-gpu` | `model == 'BLEEDING-EDGE-GPU'` | 0 (every GPU is `LATEST-GPU-MODEL`) | skipped |
+| 2 | `huge-gpu` | `memory >= 1Ti` | 0 (every GPU is `80Gi`) | skipped |
+| 3 | `older-gpu` | none | any GPU | **allocated** |
+
+**pod1 — preference.** Both subrequests can be satisfied, so the higher-priority
+one wins even though the lower-priority one would also work:
+
+| # | Subrequest | Selector | Devices matched | Result |
+| - | ---------- | -------- | --------------- | ------ |
+| 1 | `latest-gpu` | `model == 'LATEST-GPU-MODEL'` | any GPU | **allocated** |
+| 2 | `older-gpu` | none | any GPU | not reached |
+
+The selectors compare against attributes and capacities the driver advertises,
+not anything defined in the claim. A subrequest whose selector matches zero
+devices cannot be satisfied, so the scheduler moves on to the next one in the
+list.
+
+## Requirements
+
+### Driver Requirements
+
+- **Profile**: gpu
+- **GPUs**: 2 (one per pod)
+
+### Cluster Requirements
+
+- **Kubernetes 1.34+** with the `DRAPrioritizedList` feature gate enabled
+  - Beta and enabled by default in Kubernetes 1.34–1.35
+  - GA in Kubernetes 1.36+
+
+## How to Run
+
+1. Apply the example:
+
+   ```bash
+   cd demo/examples/prioritized-alternatives && kubectl apply -f prioritized-alternatives.yaml
+   ```
+
+2. Verify the pods are running:
+
+   ```bash
+   kubectl get pods -n prioritized-alternatives
+   ```
+
+3. Check a GPU was injected into each container:
+
+   ```bash
+   kubectl logs -n prioritized-alternatives pod0 -c ctr0 | grep GPU_DEVICE
+   kubectl logs -n prioritized-alternatives pod1 -c ctr0 | grep GPU_DEVICE
+   ```
+
+4. Check which subrequest the scheduler chose for each pod:
+
+   ```bash
+   kubectl get resourceclaim -n prioritized-alternatives \
+     -o jsonpath='{range .items[*]}{.status.allocation.devices.results[*].request}{"\n"}{end}'
+   ```
+
+## Expected Output
+
+- **Pod Status**: Both pods should be running successfully.
+- **GPU Allocation**: Each container has exactly one `GPU_DEVICE` environment
+  variable, and the two pods get distinct GPUs.
+- **Chosen Subrequest**: The allocation results reference the chosen subrequest
+  using the `<main request>/<subrequest>` format:
+
+  ```
+  gpu/older-gpu     # pod0 fell back to the only satisfiable subrequest
+  gpu/latest-gpu    # pod1 preferred the higher-priority subrequest
+  ```
+
+## Cleanup
+
+```bash
+cd demo/examples/prioritized-alternatives && kubectl delete -f prioritized-alternatives.yaml
+```

--- a/demo/examples/prioritized-alternatives/prioritized-alternatives.yaml
+++ b/demo/examples/prioritized-alternatives/prioritized-alternatives.yaml
@@ -1,0 +1,138 @@
+# Example: Prioritized Alternatives in Device Requests (KEP-4816)
+#
+# Two pods, one container each. Each pod's single DeviceRequest named "gpu"
+# provides a prioritized list of alternatives via the `firstAvailable` field.
+# The scheduler tries the subrequests in order and satisfies the request with
+# the first one that fits.
+#
+# pod0 demonstrates FALLBACK: the first two subrequests can't match any device,
+# so the request falls through to the third.
+#   1. bleeding-edge-gpu - selects on model == "BLEEDING-EDGE-GPU"
+#                          (no device matches; the driver publishes
+#                          model == "LATEST-GPU-MODEL")
+#   2. huge-gpu          - selects on memory >= 1Ti
+#                          (no device matches; the driver publishes 80Gi)
+#   3. older-gpu         - no selectors; matches any GPU in the class -> chosen
+#
+# pod1 demonstrates PREFERENCE: both subrequests can match, so the scheduler
+# picks the higher-priority one.
+#   1. latest-gpu        - selects on model == "LATEST-GPU-MODEL" (matches) -> chosen
+#   2. older-gpu         - no selectors; also matches, but lower priority
+#
+# Together these mirror KEP-4816 user story 1: prefer a high-end GPU, but accept
+# a less specialized one if the preferred options are not available.
+#
+# Expected: each pod gets exactly 1 GPU. pod0 is satisfied via "older-gpu" and
+# pod1 via "latest-gpu".
+# Check the GPUs were injected:
+#   kubectl logs -n prioritized-alternatives pod0 -c ctr0 | grep GPU_DEVICE
+#   kubectl logs -n prioritized-alternatives pod1 -c ctr0 | grep GPU_DEVICE
+# Check which subrequest the scheduler chose for each pod (the request field is
+# "gpu/older-gpu" for pod0 and "gpu/latest-gpu" for pod1):
+#   kubectl get resourceclaim -n prioritized-alternatives \
+#     -o jsonpath='{range .items[*]}{.status.allocation.devices.results[*].request}{"\n"}{end}'
+#
+# Driver requirements:
+#   Profile: gpu
+#   GPUs: 2
+#
+# Cluster requirements:
+#   Kubernetes 1.34+ with the DRAPrioritizedList feature gate enabled
+#   (Beta and on by default in 1.34-1.35; GA in 1.36+)
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prioritized-alternatives
+
+---
+# pod0: fallback. The first two subrequests match no device, so the request is
+# satisfied by the third, "older-gpu".
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: prioritized-alternatives
+  name: prioritized-gpu
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        firstAvailable:
+        - name: bleeding-edge-gpu
+          deviceClassName: gpu.example.com
+          selectors:
+          - cel:
+              expression: "device.attributes['gpu.example.com'].model == 'BLEEDING-EDGE-GPU'"
+        - name: huge-gpu
+          deviceClassName: gpu.example.com
+          selectors:
+          - cel:
+              expression: "device.capacity['gpu.example.com'].memory.compareTo(quantity('1Ti')) >= 0"
+        - name: older-gpu
+          deviceClassName: gpu.example.com
+
+---
+# pod1: preference. Both subrequests match, so the scheduler chooses the
+# higher-priority one, "latest-gpu".
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: prioritized-alternatives
+  name: preferred-gpu
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        firstAvailable:
+        - name: latest-gpu
+          deviceClassName: gpu.example.com
+          selectors:
+          - cel:
+              expression: "device.attributes['gpu.example.com'].model == 'LATEST-GPU-MODEL'"
+        - name: older-gpu
+          deviceClassName: gpu.example.com
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: prioritized-alternatives
+  name: pod0
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: prioritized-gpu
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: prioritized-alternatives
+  name: pod1
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: preferred-gpu

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -565,6 +565,49 @@ func getClaimDeviceShares(ctx context.Context, namespace, podName, podLocalClaim
 	return shares
 }
 
+// verifyChosenSubrequest verifies that the ResourceClaim generated for the
+// pod-local claim podLocalClaimName was satisfied by the expected subrequest of
+// a DeviceRequest using the firstAvailable field (KEP-4816). The scheduler
+// records the selected subrequest in
+// claim.status.allocation.devices.results[].request using the "<main>/<sub>"
+// format, so expectedRequest should be given in that form.
+func verifyChosenSubrequest(ctx context.Context, namespace, podName, podLocalClaimName, driverName, expectedRequest string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s/%s", namespace, podName)
+
+		rcsIdx := slices.IndexFunc(pod.Status.ResourceClaimStatuses, func(s v1.PodResourceClaimStatus) bool {
+			return s.Name == podLocalClaimName && s.ResourceClaimName != nil
+		})
+		g.Expect(rcsIdx).NotTo(Equal(-1),
+			"Pod %s/%s has no resourceClaimStatuses entry for pod-local claim %q; status: %+v",
+			namespace, podName, podLocalClaimName, pod.Status.ResourceClaimStatuses)
+		claimName := *pod.Status.ResourceClaimStatuses[rcsIdx].ResourceClaimName
+
+		claim, err := clientset.ResourceV1().ResourceClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to get ResourceClaim %s/%s", namespace, claimName)
+		g.Expect(claim.Status.Allocation).NotTo(BeNil(),
+			"ResourceClaim %s/%s is not yet allocated", namespace, claimName)
+
+		var driverResults []resourceapi.DeviceRequestAllocationResult
+		for _, r := range claim.Status.Allocation.Devices.Results {
+			if r.Driver == driverName {
+				driverResults = append(driverResults, r)
+			}
+		}
+		g.Expect(driverResults).To(HaveLen(1),
+			"ResourceClaim %s/%s should have exactly one allocation result for driver %q, got %+v",
+			namespace, claimName, driverName, claim.Status.Allocation.Devices.Results)
+		g.Expect(driverResults[0].Request).To(Equal(expectedRequest),
+			"ResourceClaim %s/%s was satisfied by request %q, expected %q",
+			namespace, claimName, driverResults[0].Request, expectedRequest)
+
+		fmt.Fprintf(GinkgoWriter, "ResourceClaim %s/%s satisfied by request %q\n",
+			namespace, claimName, driverResults[0].Request)
+	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}
+
 // expectedMapping describes the asserted shape of a single
 // NodeAllocatableResourceMapping. Exactly one of AllocationMultiplier and
 // CapacityKey should be set; whichever is set is what the helper asserts.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -204,6 +204,27 @@ var _ = Describe("Test GPU allocation", func() {
 		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
 	})
 
+	It("should honor firstAvailable priority order, preferring higher-priority subrequests and falling back when they don't match", func(ctx SpecContext) {
+		drv := installDriver(ctx, DriverConfig{})
+		namespace := "prioritized-alternatives"
+		pods := []string{"pod0", "pod1"}
+		containerName := "ctr0"
+		expectedGPUCount := 1
+
+		deployManifest(ctx, namespace, "prioritized-alternatives.yaml", drv)
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+
+		observedGPUs := make(map[string]string)
+		for _, podName := range pods {
+			verifyGPUAllocation(ctx, namespace, podName, containerName, expectedGPUCount, observedGPUs)
+		}
+
+		// pod0 falls through to the only satisfiable subrequest.
+		verifyChosenSubrequest(ctx, namespace, "pod0", "gpu", drv.DriverName, "gpu/older-gpu")
+		// pod1 has two satisfiable subrequests, so the higher-priority one wins.
+		verifyChosenSubrequest(ctx, namespace, "pod1", "gpu", drv.DriverName, "gpu/latest-gpu")
+	})
+
 	It("Should share 1 GPU among the Pods in each of 2 PodGroups", func(ctx SpecContext) {
 		drv := installDriver(ctx, DriverConfig{})
 		namespace := "podgroup-resourceclaimtemplate"


### PR DESCRIPTION
Fixes #182

Adds a demo and e2e test demonstrating [KEP-4816](https://github.com/kubernetes/enhancements/issues/4816) (DRA: Prioritized Alternatives in Device Requests), which lets a single `DeviceRequest` offer a priority-ordered list of alternatives via the `firstAvailable` field. The scheduler tries each subrequest in order and allocates the first one that fits, so a workload can prefer a high-end device but still run on a less specialized one when the preferred options aren't available.

### How the example works

The example has two pods, each with one `gpu` request that lists subrequests in priority order. The scheduler uses the first subrequest that can be satisfied, and records it in `status.allocation.devices.results[].request` as `<request>/<subrequest>`.

**pod0 — fallback.** The first two subrequests select on values no device has, so the request falls through to the third (`gpu/older-gpu`):

1. **`bleeding-edge-gpu`** — CEL `model == "BLEEDING-EDGE-GPU"` (never matches; driver publishes `LATEST-GPU-MODEL`)
2. **`huge-gpu`** — CEL `memory >= 1Ti` (never matches; driver publishes `80Gi`)
3. **`older-gpu`** — no selectors, matches any GPU

**pod1 — preference.** Both subrequests can match, so the higher-priority one wins (`gpu/latest-gpu`):

1. **`latest-gpu`** — CEL `model == "LATEST-GPU-MODEL"` (matches)
2. **`older-gpu`** — no selectors (also matches, but lower priority)

No driver change is needed: the driver allocates by device name and matches configs by request name, both of which work transparently with the new `<request>/<subrequest>` format.

### Changes

- `demo/examples/prioritized-alternatives/prioritized-alternatives.yaml` — the example (Namespace + two ResourceClaimTemplates + two Pods).
- `demo/examples/prioritized-alternatives/README.md` — per-example doc with a mermaid diagram of both cases, requirements, and run/verify steps.
- `test/e2e/e2e_test.go` — new spec that deploys the example, confirms each pod gets a distinct GPU, and asserts pod0 was satisfied by `gpu/older-gpu` (fallback) and pod1 by `gpu/latest-gpu` (preference).
- `test/e2e/e2e_setup_test.go` — new `verifyChosenSubrequest` helper that resolves the generated `ResourceClaim` and checks which subrequest the scheduler selected.