### PR TITLE
Add claimName parameter to ApplyConfig interface

### DIFF
--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -318,7 +318,7 @@ func (s *DeviceState) computeDeviceConfig(claim *resourceapi.ResourceClaim) (Pre
 	perDeviceCDIContainerEdits := make(profiles.PerDeviceCDIContainerEdits)
 	for config, results := range configResultsMap {
 		// Apply the config to the list of results associated with it.
-		containerEdits, err := s.configHandler.ApplyConfig(config, results)
+		containerEdits, err := s.configHandler.ApplyConfig(claim.Name, config, results)
 		if err != nil {
 			return nil, fmt.Errorf("error applying config: %w", err)
 		}

--- a/internal/profiles/cpu/cpu.go
+++ b/internal/profiles/cpu/cpu.go
@@ -108,7 +108,7 @@ func (p Profile) Validate(config runtime.Object) error {
 // configuration and otherwise injects env vars per allocated NUMA device so
 // the demo container can show which device was allocated and how much CPU
 // capacity was consumed.
-func (p Profile) ApplyConfig(config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (profiles.PerDeviceCDIContainerEdits, error) {
+func (p Profile) ApplyConfig(claimName string, config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (profiles.PerDeviceCDIContainerEdits, error) {
 	if config != nil {
 		return nil, errors.New("configuration not allowed")
 	}

--- a/internal/profiles/cpu/cpu_test.go
+++ b/internal/profiles/cpu/cpu_test.go
@@ -81,7 +81,7 @@ func TestApplyConfig(t *testing.T) {
 		},
 	}}
 
-	edits, err := profile.ApplyConfig(nil, results)
+	edits, err := profile.ApplyConfig("test-claim", nil, results)
 	require.NoError(t, err)
 	require.Contains(t, edits, "numa-0")
 	assert.ElementsMatch(t,

--- a/internal/profiles/gpu/gpu.go
+++ b/internal/profiles/gpu/gpu.go
@@ -241,7 +241,7 @@ func (p Profile) Validate(config runtime.Object) error {
 }
 
 // ApplyConfig implements [profiles.ConfigHandler].
-func (p Profile) ApplyConfig(config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (profiles.PerDeviceCDIContainerEdits, error) {
+func (p Profile) ApplyConfig(claimName string, config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (profiles.PerDeviceCDIContainerEdits, error) {
 	if config == nil {
 		config = configapi.DefaultGpuConfig()
 	}

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -41,8 +41,10 @@ type ConfigHandler interface {
 	Validate(config runtime.Object) error
 	// ApplyConfig applies a configuration to a set of device allocation
 	// results. When `config` is nil, the profile's default configuration should
-	// be applied.
-	ApplyConfig(config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (PerDeviceCDIContainerEdits, error)
+	// be applied. The claimName parameter provides the name of the ResourceClaim
+	// being prepared, which can be used to generate claim-specific CDI configurations
+	// (e.g., unique mount paths, claim-specific identifiers).
+	ApplyConfig(claimName string, config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (PerDeviceCDIContainerEdits, error)
 }
 
 // NoopConfigHandler implements a [ConfigHandler] that does not allow
@@ -50,7 +52,7 @@ type ConfigHandler interface {
 type NoopConfigHandler struct{}
 
 // ApplyConfig implements [ConfigHandler].
-func (n NoopConfigHandler) ApplyConfig(config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (PerDeviceCDIContainerEdits, error) {
+func (n NoopConfigHandler) ApplyConfig(claimName string, config runtime.Object, results []*resourceapi.DeviceRequestAllocationResult) (PerDeviceCDIContainerEdits, error) {
 	if config != nil {
 		return nil, errors.New("configuration not allowed")
 	}


### PR DESCRIPTION
This change adds the ResourceClaim name as a parameter to the ApplyConfig method in the Profile interface. This enables profiles to generate claim-specific CDI configurations, such as unique mount paths or claim-specific identifiers.

Use case: Profiles that need to create per-claim resources (directories, device configurations, etc.) can use the claim name to ensure uniqueness and avoid conflicts when multiple claims use the same device type.

Example: A network profile that creates per-claim directories:
  /var/run/devices/<claim-name>/device-0/

Changes:
- Add claimName parameter to ConfigHandler.ApplyConfig interface
- Update GPU profile to accept (but not use) claimName parameter
- Update CPU profile to accept (but not use) claimName parameter
- Update state.go to pass claim.Name to ApplyConfig
- Update CPU test to pass dummy claimName

All existing profiles continue to work unchanged - they simply ignore the claimName parameter if not needed.