### PR TITLE
metrics: add Prometheus endpoint and driver instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ driver_image.tar
 
 # Ignore config telemetry files
 .config/
+
+# Ignore .bin files
+.bin/

--- a/cmd/dra-example-kubeletplugin/driver.go
+++ b/cmd/dra-example-kubeletplugin/driver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,6 +28,8 @@ import (
 	coreclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/dra-example-driver/pkg/metrics"
 )
 
 type driver struct {
@@ -94,15 +97,22 @@ func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceap
 	return result, nil
 }
 
-func (d *driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
+func (d *driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) (result kubeletplugin.PrepareResult) {
 	logger := klog.FromContext(ctx)
 	logger.Info("Preparing claim", "uid", claim.UID, "namespace", claim.Namespace, "name", claim.Name)
+
+	start := time.Now()
+	defer func() {
+		metrics.ObservePrepareClaim(result.Err, time.Since(start))
+	}()
+
 	preparedDevices, err := d.state.Prepare(ctx, claim)
 	if err != nil {
 		logger.Error(err, "Error preparing devices for claim", "uid", claim.UID)
-		return kubeletplugin.PrepareResult{
+		result = kubeletplugin.PrepareResult{
 			Err: fmt.Errorf("error preparing devices for claim %v: %w", claim.UID, err),
 		}
+		return result
 	}
 	var prepared []kubeletplugin.Device
 	for _, preparedDevice := range preparedDevices {
@@ -116,7 +126,8 @@ func (d *driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.Re
 	}
 
 	logger.Info("Returning newly prepared devices for claim", "uid", claim.UID, "devices", prepared)
-	return kubeletplugin.PrepareResult{Devices: prepared}
+	result = kubeletplugin.PrepareResult{Devices: prepared}
+	return result
 }
 
 func (d *driver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
@@ -131,8 +142,13 @@ func (d *driver) UnprepareResourceClaims(ctx context.Context, claims []kubeletpl
 	return result, nil
 }
 
-func (d *driver) unprepareResourceClaim(_ context.Context, claim kubeletplugin.NamespacedObject) error {
-	if err := d.state.Unprepare(claim.UID); err != nil {
+func (d *driver) unprepareResourceClaim(_ context.Context, claim kubeletplugin.NamespacedObject) (err error) {
+	start := time.Now()
+	defer func() {
+		metrics.ObserveUnprepareClaim(err, time.Since(start))
+	}()
+
+	if err = d.state.Unprepare(claim.UID); err != nil {
 		return fmt.Errorf("error unpreparing devices for claim %v: %w", claim.UID, err)
 	}
 
@@ -141,7 +157,10 @@ func (d *driver) unprepareResourceClaim(_ context.Context, claim kubeletplugin.N
 
 func (d *driver) HandleError(ctx context.Context, err error, msg string) {
 	utilruntime.HandleErrorWithContext(ctx, err, msg)
-	if !errors.Is(err, kubeletplugin.ErrRecoverable) && d.cancelCtx != nil {
-		d.cancelCtx(fmt.Errorf("fatal background error: %w", err))
+	if !errors.Is(err, kubeletplugin.ErrRecoverable) {
+		metrics.FatalBackgroundErrorsTotal.Inc()
+		if d.cancelCtx != nil {
+			d.cancelCtx(fmt.Errorf("fatal background error: %w", err))
+		}
 	}
 }

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -282,13 +282,13 @@ func RunPlugin(ctx context.Context, config *Config) error {
 	if err != nil {
 		return fmt.Errorf("start metrics server: %w", err)
 	}
-	defer func() {
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer func(ctx context.Context) {
+		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
 		defer shutdownCancel()
 		if err := metricsServer.Stop(shutdownCtx); err != nil {
 			logger.Error(err, "failed to stop metrics server")
 		}
-	}()
+	}(context.WithoutCancel(ctx))
 
 	driver, err := NewDriver(ctx, config)
 	if err != nil {

--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/dra-example-driver/internal/profiles/cpu"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/gpu"
 	"sigs.k8s.io/dra-example-driver/pkg/flags"
+	"sigs.k8s.io/dra-example-driver/pkg/metrics"
 )
 
 const (
@@ -51,6 +53,7 @@ type Flags struct {
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
+	metricsPort                   int
 	profile                       string
 	driverName                    string
 	podUID                        string
@@ -143,6 +146,13 @@ func newApp() *cli.App {
 			Value:       -1,
 			Destination: &flags.healthcheckPort,
 			EnvVars:     []string{"HEALTHCHECK_PORT"},
+		},
+		&cli.IntFlag{
+			Name:        "metrics-port",
+			Usage:       "Port to expose Prometheus metrics at /metrics. When positive, a literal port number. When zero, a random port is allocated. When negative, metrics are disabled.",
+			Value:       -1,
+			Destination: &flags.metricsPort,
+			EnvVars:     []string{"METRICS_PORT"},
 		},
 		&cli.StringFlag{
 			Name:        "device-profile",
@@ -267,6 +277,18 @@ func RunPlugin(ctx context.Context, config *Config) error {
 	defer stop()
 	ctx, cancel := context.WithCancelCause(ctx)
 	config.cancelMainCtx = cancel
+
+	metricsServer, err := metrics.StartServer(ctx, config.flags.metricsPort)
+	if err != nil {
+		return fmt.Errorf("start metrics server: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := metricsServer.Stop(shutdownCtx); err != nil {
+			logger.Error(err, "failed to stop metrics server")
+		}
+	}()
 
 	driver, err := NewDriver(ctx, config)
 	if err != nil {

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin-metrics-svc.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin-metrics-svc.yaml
@@ -1,0 +1,19 @@
+{{- if (gt (int .Values.kubeletPlugin.containers.plugin.metricsPort) 0) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dra-example-driver.fullname" . }}-kubeletplugin-metrics
+  namespace: {{ include "dra-example-driver.namespace" . }}
+  labels:
+    {{- include "dra-example-driver.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubeletplugin
+spec:
+  selector:
+    {{- include "dra-example-driver.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kubeletplugin
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: {{ .Values.kubeletPlugin.containers.plugin.metricsPort }}
+    targetPort: metrics
+{{- end }}

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -58,6 +58,12 @@ spec:
           failureThreshold: 3
           periodSeconds: 10
         {{- end }}
+        {{- if (gt (int .Values.kubeletPlugin.containers.plugin.metricsPort) 0) }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.kubeletPlugin.containers.plugin.metricsPort }}
+          protocol: TCP
+        {{- end }}
         env:
         - name: DRIVER_NAME
           value: {{ include "dra-example-driver.driverName" . | quote }}
@@ -82,9 +88,13 @@ spec:
           value: {{ .Values.kubeletPlugin.numDevices | quote }}
         - name: GPU_DEVICE_STATUS
           value: {{ .Values.gpuDeviceStatus | quote }}
-        {{- if .Values.kubeletPlugin.containers.plugin.healthcheckPort }}
+        {{- if (gt (int .Values.kubeletPlugin.containers.plugin.healthcheckPort) 0) }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}
+        {{- end }}
+        {{- if (gt (int .Values.kubeletPlugin.containers.plugin.metricsPort) 0) }}
+        - name: METRICS_PORT
+          value: {{ .Values.kubeletPlugin.containers.plugin.metricsPort | quote }}
         {{- end }}
         - name: GPU_PARTITIONS
           value: {{ .Values.kubeletPlugin.gpuPartitions | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -92,6 +92,9 @@ kubeletPlugin:
       # Port running a gRPC health service checked by a livenessProbe.
       # Set to a negative value to disable the service and the probe.
       healthcheckPort: 51515
+      # Port exposing Prometheus metrics at /metrics.
+      # Set to a negative value to disable the metrics server.
+      metricsPort: 8080
 
 controller:
   # plugins is a list of plugins to enable in the controller.

--- a/pkg/flags/kubeclient.go
+++ b/pkg/flags/kubeclient.go
@@ -24,6 +24,10 @@ import (
 	coreclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	// Register client-go REST client metrics with the Prometheus registry
+	// used by pkg/metrics (rest_client_requests_total, etc.).
+	_ "k8s.io/component-base/metrics/prometheus/restclient"
 )
 
 type KubeClientConfig struct {

--- a/pkg/flags/kubeclient_test.go
+++ b/pkg/flags/kubeclient_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+func TestRestClientMetricsRegistered(t *testing.T) {
+	t.Parallel()
+
+	// Gauge metrics from the restclient package are exported as soon as the
+	// package is linked via kubeclient.go's blank import.
+	require.True(t, hasMetricFamily(t, "rest_client_transport_cache_entries"))
+}
+
+func TestRestClientMetricsObservedOnRequest(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"NodeList","apiVersion":"v1","items":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := coreclientset.NewForConfig(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+
+	_, err = client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	require.True(t, hasMetricFamily(t, "rest_client_requests_total"))
+}
+
+func hasMetricFamily(t *testing.T, name string) bool {
+	t.Helper()
+
+	metricFamilies, err := legacyregistry.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, family := range metricFamilies {
+		if family.GetName() == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/metrics/driver.go
+++ b/pkg/metrics/driver.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"time"
+
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	resultSuccess = "success"
+	resultError   = "error"
+)
+
+var (
+	PrepareClaimsTotal = k8smetrics.NewCounterVec(&k8smetrics.CounterOpts{
+		Namespace:      Namespace,
+		Subsystem:      Subsystem,
+		Name:           "prepare_claims_total",
+		StabilityLevel: k8smetrics.BETA,
+		Help:           "Total number of resource claim prepare operations handled by the driver.",
+	}, []string{"result"})
+
+	PrepareClaimDurationSeconds = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
+		Namespace:      Namespace,
+		Subsystem:      Subsystem,
+		Name:           "prepare_claim_duration_seconds",
+		StabilityLevel: k8smetrics.BETA,
+		Help:           "Latency in seconds of resource claim prepare operations handled by the driver.",
+		Buckets:        k8smetrics.DefBuckets,
+	}, []string{"result"})
+
+	UnprepareClaimsTotal = k8smetrics.NewCounterVec(&k8smetrics.CounterOpts{
+		Namespace:      Namespace,
+		Subsystem:      Subsystem,
+		Name:           "unprepare_claims_total",
+		StabilityLevel: k8smetrics.BETA,
+		Help:           "Total number of resource claim unprepare operations handled by the driver.",
+	}, []string{"result"})
+
+	UnprepareClaimDurationSeconds = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
+		Namespace:      Namespace,
+		Subsystem:      Subsystem,
+		Name:           "unprepare_claim_duration_seconds",
+		StabilityLevel: k8smetrics.BETA,
+		Help:           "Latency in seconds of resource claim unprepare operations handled by the driver.",
+		Buckets:        k8smetrics.DefBuckets,
+	}, []string{"result"})
+
+	FatalBackgroundErrorsTotal = k8smetrics.NewCounter(&k8smetrics.CounterOpts{
+		Namespace:      Namespace,
+		Subsystem:      Subsystem,
+		Name:           "fatal_background_errors_total",
+		StabilityLevel: k8smetrics.BETA,
+		Help:           "Total number of fatal background errors reported by the driver.",
+	})
+
+	driverMetrics = []k8smetrics.Registerable{
+		PrepareClaimsTotal,
+		PrepareClaimDurationSeconds,
+		UnprepareClaimsTotal,
+		UnprepareClaimDurationSeconds,
+		FatalBackgroundErrorsTotal,
+	}
+)
+
+func init() {
+	for _, metric := range driverMetrics {
+		legacyregistry.MustRegister(metric)
+	}
+	initDriverMetricSeries()
+}
+
+// initDriverMetricSeries creates zero-valued counter time series so they are
+// visible in /metrics before the first prepare or unprepare operation.
+func initDriverMetricSeries() {
+	for _, result := range []string{resultSuccess, resultError} {
+		PrepareClaimsTotal.WithLabelValues(result).Add(0)
+		UnprepareClaimsTotal.WithLabelValues(result).Add(0)
+	}
+}
+
+// ObservePrepareClaim records metrics for a single prepare operation.
+func ObservePrepareClaim(err error, duration time.Duration) {
+	result := resultSuccess
+	if err != nil {
+		result = resultError
+	}
+	PrepareClaimsTotal.WithLabelValues(result).Inc()
+	PrepareClaimDurationSeconds.WithLabelValues(result).Observe(duration.Seconds())
+}
+
+// ObserveUnprepareClaim records metrics for a single unprepare operation.
+func ObserveUnprepareClaim(err error, duration time.Duration) {
+	result := resultSuccess
+	if err != nil {
+		result = resultError
+	}
+	UnprepareClaimsTotal.WithLabelValues(result).Inc()
+	UnprepareClaimDurationSeconds.WithLabelValues(result).Observe(duration.Seconds())
+}

--- a/pkg/metrics/driver_test.go
+++ b/pkg/metrics/driver_test.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+func TestObservePrepareClaim(t *testing.T) {
+	t.Parallel()
+
+	ObservePrepareClaim(nil, 25*time.Millisecond)
+	ObservePrepareClaim(errors.New("prepare failed"), 50*time.Millisecond)
+
+	require.Equal(t, float64(1), counterValue(t, "dra_example_driver_prepare_claims_total", map[string]string{"result": "success"}))
+	require.Equal(t, float64(1), counterValue(t, "dra_example_driver_prepare_claims_total", map[string]string{"result": "error"}))
+}
+
+func TestObserveUnprepareClaim(t *testing.T) {
+	t.Parallel()
+
+	ObserveUnprepareClaim(nil, 10*time.Millisecond)
+	ObserveUnprepareClaim(errors.New("unprepare failed"), 20*time.Millisecond)
+
+	require.Equal(t, float64(1), counterValue(t, "dra_example_driver_unprepare_claims_total", map[string]string{"result": "success"}))
+	require.Equal(t, float64(1), counterValue(t, "dra_example_driver_unprepare_claims_total", map[string]string{"result": "error"}))
+}
+
+func counterValue(t *testing.T, name string, labels map[string]string) float64 {
+	t.Helper()
+
+	metrics, err := legacyregistry.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, metricFamily := range metrics {
+		if metricFamily.GetName() != name {
+			continue
+		}
+		for _, metric := range metricFamily.GetMetric() {
+			if !labelsMatch(metric.GetLabel(), labels) {
+				continue
+			}
+			return metric.GetCounter().GetValue()
+		}
+	}
+
+	t.Fatalf("metric %q with labels %v not found", name, labels)
+	return 0
+}
+
+func labelsMatch(got []*dto.LabelPair, want map[string]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for _, label := range got {
+		if want[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package metrics provides Prometheus metrics for the DRA example driver.
+package metrics
+
+const (
+	// Namespace is the Prometheus metrics namespace for driver metrics.
+	Namespace = "dra_example"
+
+	// Subsystem is the Prometheus metrics subsystem for driver metrics.
+	Subsystem = "driver"
+)

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+// Server serves Prometheus metrics over HTTP.
+type Server struct {
+	httpServer *http.Server
+	addr       string
+	wg         sync.WaitGroup
+}
+
+// StartServer starts an HTTP server that exposes Prometheus metrics at /metrics.
+// When port is negative, the server is not started and (nil, nil) is returned.
+func StartServer(ctx context.Context, port int) (*Server, error) {
+	log := klog.FromContext(ctx)
+
+	if port < 0 {
+		return nil, nil
+	}
+
+	addr := net.JoinHostPort("", strconv.Itoa(port))
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", legacyregistry.HandlerWithReset())
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen for metrics server at %s: %w", addr, err)
+	}
+
+	server := &Server{
+		httpServer: &http.Server{
+			Handler: mux,
+		},
+		addr: listener.Addr().String(),
+	}
+
+	server.wg.Add(1)
+	go func() {
+		defer server.wg.Done()
+		log.Info("starting metrics server", "addr", listener.Addr().String())
+		if err := server.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Error(err, "failed to serve metrics", "addr", addr)
+		}
+	}()
+
+	return server, nil
+}
+
+// Addr returns the address the metrics server is listening on.
+func (s *Server) Addr() string {
+	if s == nil {
+		return ""
+	}
+	return s.addr
+}
+
+// Stop gracefully shuts down the metrics server.
+func (s *Server) Stop(ctx context.Context) error {
+	if s == nil || s.httpServer == nil {
+		return nil
+	}
+
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutdown metrics server: %w", err)
+	}
+	s.wg.Wait()
+	return nil
+}

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -64,4 +64,6 @@ func TestStartServerServesMetrics(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(body), "go_goroutines")
+	require.Contains(t, string(body), "dra_example_driver_prepare_claims_total")
+	require.Contains(t, string(body), "dra_example_driver_unprepare_claims_total")
 }

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartServerDisabled(t *testing.T) {
+	t.Parallel()
+
+	server, err := StartServer(context.Background(), -1)
+	require.NoError(t, err)
+	require.Nil(t, server)
+}
+
+func TestStartServerServesMetrics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, err := StartServer(ctx, 0)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, server.Stop(shutdownCtx))
+	})
+
+	addr := server.Addr()
+	require.NotEmpty(t, addr)
+
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get("http://" + addr + "/metrics")
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "go_goroutines")
+}


### PR DESCRIPTION
## Summary

Adds Prometheus metrics support for the DRA example kubelet plugin

- Introduce `pkg/metrics` with an HTTP `/metrics` server using `k8s.io/component-base/metrics/legacyregistry`
- Wire an optional `--metrics-port` / `METRICS_PORT` flag into the kubelet plugin
- Instrument driver prepare/unprepare operations (counters, latency histograms, fatal background errors)
- Register standard client-go REST API metrics via `component-base/metrics/prometheus/restclient` in `pkg/flags/kubeclient.go`
- Expose metrics in Helm (`metricsPort: 8080`, container port, env var and a ClusterIP Service for scraping)

Fixes #134

## Metrics

| Metric | Type | Notes |
|--------|------|-------|
| `dra_example_driver_prepare_claims_total{result}` | Counter | Pre-initialized at 0 |
| `dra_example_driver_prepare_claim_duration_seconds{result}` | Histogram | After first prepare |
| `dra_example_driver_unprepare_claims_total{result}` | Counter | Pre-initialized at 0 |
| `dra_example_driver_unprepare_claim_duration_seconds{result}` | Histogram | After first unprepare |
| `dra_example_driver_fatal_background_errors_total` | Counter | Non-recoverable errors |
| `rest_client_*` | Various | Standard client-go API metrics |

## Test plan

- [x] `go test ./pkg/metrics/...`
- [x] `go test ./pkg/flags/...`
- [x] `helm template test deployments/helm/dra-example-driver --namespace dra-example-driver` — verify `METRICS_PORT`, port `8080`, metrics Service
- [ ] `make setup-e2e && make test-e2e` (existing e2e no metrics assertions yet)
- [ ] Deploy upgraded chart to kind and scrape metrics:
  ```bash
  kubectl port-forward -n <ns> svc/<release>-dra-example-driver-kubeletplugin-metrics 8080:8080
  curl -s localhost:8080/metrics | grep -E 'dra_example_driver|rest_client'
  ```

## Notes

- Metrics are disabled by default when `--metrics-port` / `METRICS_PORT` is negative (local dev) Helm enables port `8080` by default.
- Histogram and some `rest_client_*` series only appear after the corresponding operations occur (standard Prometheus behavior).