### PR TITLE
Add AllowMultipleAllocations and requestPolicy of consumable capacity to GPU profile

### DIFF
--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -61,6 +61,7 @@ type Flags struct {
 	gpuPartitions                 int
 	gpuDeviceStatus               bool
 	bindingConditions             bool
+	gpuAllowMultipleAllocations   bool
 	cpuNUMANodes                  int
 	cpusPerNUMANode               int
 }
@@ -75,7 +76,7 @@ type Config struct {
 
 var validProfiles = map[string]func(flags Flags) profiles.Profile{
 	gpu.ProfileName: func(flags Flags) profiles.Profile {
-		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions, flags.gpuDeviceStatus, flags.bindingConditions)
+		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions, flags.gpuDeviceStatus, flags.bindingConditions, flags.gpuAllowMultipleAllocations)
 	},
 	cpu.ProfileName: func(flags Flags) profiles.Profile {
 		return cpu.NewProfile(flags.nodeName, flags.driverName, flags.cpuNUMANodes, flags.cpusPerNUMANode)
@@ -196,6 +197,12 @@ func newApp() *cli.App {
 			Value:       false,
 			Destination: &flags.bindingConditions,
 			EnvVars:     []string{"BINDING_CONDITIONS"},
+		},
+		&cli.BoolFlag{
+			Name:        "gpu-allow-multiple-allocations",
+			Usage:       "Allow GPU devices to be allocated to multiple DeviceRequests. Disabled by default.",
+			Destination: &flags.gpuAllowMultipleAllocations,
+			EnvVars:     []string{"GPU_ALLOW_MULTIPLE_ALLOCATIONS"},
 		},
 		&cli.IntFlag{
 			Name:        "cpu-numa-nodes",

--- a/demo/examples/gpu-allow-multiple-allocations-partitionable/README.md
+++ b/demo/examples/gpu-allow-multiple-allocations-partitionable/README.md
@@ -1,0 +1,134 @@
+# GPU Allow Multiple Allocations — Partitionable Example
+
+## Overview
+
+This example combines two features: **DRAConsumableCapacity** (multiple allocations) and **DRAPartitionableDevices** (partition slices). Two pods each request a slice of a partition device's `memory` and `compute` counters. The partition devices share counters with the physical GPU, so the scheduler can track that the consumed capacity comes from the same physical hardware.
+
+**Setup**: Two pods, each with one container, each consuming 8Gi memory and 10 compute units from a GPU partition device.
+
+## What This Example Shows
+
+- How `AllowMultipleAllocations` and partitionable devices work together
+- Using `capacity.requests` on a partition device to consume fine-grained slices
+- Both `DRAConsumableCapacity` and `DRAPartitionableDevices` feature gates in practice
+
+## GPU Allocation
+
+```mermaid
+graph TD
+    subgraph Node["Node (Physical Hardware)"]
+        subgraph GPU1["GPU 1 (Physical)"]
+            SC["Shared Counters<br/>memory: 80Gi<br/>compute: 100"]
+            P1["Partition 1<br/>(AllowMultipleAllocations)"]
+            P2["Partition 2"]
+            SC -.tracks.-> P1
+            SC -.tracks.-> P2
+        end
+    end
+
+    subgraph Pod1 [Pod 0]
+        C1(ctr0)
+    end
+    subgraph Pod2 [Pod 1]
+        C2(ctr0)
+    end
+
+    S1["Slice: pod0<br/>memory: 8Gi / compute: 10"]
+    S2["Slice: pod1<br/>memory: 8Gi / compute: 10"]
+
+    P1 -.consumes.-> S1
+    P1 -.consumes.-> S2
+    S1 --- C1
+    S2 --- C2
+
+    style Node fill:#e3f2fd,stroke:#333,stroke-width:2px,color:#000
+    style GPU1 fill:#e8f4f8,stroke:#326ce5,stroke-width:2px,color:#000
+    style SC fill:#fff3cd,color:#000,stroke:#856404,stroke-width:2px
+    style P1 fill:#9b59b6,color:#fff,stroke:#8e44ad,stroke-width:2px
+    style P2 fill:#95a5a6,color:#fff,stroke:#7f8c8d,stroke-width:2px
+    style S1 fill:#9b59b6,color:#fff,stroke:#8e44ad,stroke-width:1px
+    style S2 fill:#3498db,color:#fff,stroke:#2980b9,stroke-width:1px
+    style Pod1 stroke:#326ce5,stroke-width:2px
+    style Pod2 stroke:#326ce5,stroke-width:2px
+    style C1 fill:#d4edda,color:#000,stroke:#28a745,stroke-width:2px
+    style C2 fill:#d4edda,color:#000,stroke:#28a745,stroke-width:2px
+```
+
+## Requirements
+
+### Driver Requirements
+
+- **Profile**: gpu
+- **GPUs**: 1
+- Helm values: `gpuAllowMultipleAllocations=true` and `kubeletPlugin.gpuPartitions > 0`
+
+### Cluster Requirements
+
+- Kubernetes 1.35+ with both feature gates enabled:
+  - `DRAConsumableCapacity` (Alpha in 1.35, enabled by default in 1.36+)
+  - `DRAPartitionableDevices` (Alpha in 1.35, enabled by default in 1.36+)
+
+## Prerequisites
+
+Install the driver with both features enabled:
+
+```bash
+helm upgrade -i \
+  --create-namespace \
+  --namespace dra-example-driver \
+  --set gpuAllowMultipleAllocations=true \
+  --set kubeletPlugin.gpuPartitions=4 \
+  dra-example-driver \
+  deployments/helm/dra-example-driver
+```
+
+## Verification
+
+### Check ResourceSlices
+
+You should see two slices per node — one for shared counters and one for partition devices (with `AllowMultipleAllocations` set on at least one partition):
+
+```bash
+kubectl get resourceslices -o wide
+```
+
+## How to Run
+
+1. Apply the example:
+
+   ```bash
+   cd demo/examples/gpu-allow-multiple-allocations-partitionable && kubectl apply -f gpu-allow-multiple-allocations-partitionable.yaml
+   ```
+
+2. Verify both pods are running:
+
+   ```bash
+   kubectl get pods -n gpu-allow-multiple-allocations-partitionable
+   ```
+
+3. Check GPU allocation for both pods:
+
+   ```bash
+   kubectl logs -n gpu-allow-multiple-allocations-partitionable pod0 -c ctr0 | grep GPU_DEVICE
+   kubectl logs -n gpu-allow-multiple-allocations-partitionable pod1 -c ctr0 | grep GPU_DEVICE
+   ```
+
+## Expected Output
+
+Both pods should show the **same** GPU partition device ID, confirming they are sharing the same partition, each having consumed their requested capacity slice.
+
+Example output:
+
+```
+# Pod pod0
+GPU_DEVICE_0=gpu-0-partition-0
+
+# Pod pod1
+GPU_DEVICE_0=gpu-0-partition-0
+```
+
+## Cleanup
+
+```bash
+cd demo/examples/gpu-allow-multiple-allocations-partitionable && kubectl delete -f gpu-allow-multiple-allocations-partitionable.yaml
+```

--- a/demo/examples/gpu-allow-multiple-allocations-partitionable/gpu-allow-multiple-allocations-partitionable.yaml
+++ b/demo/examples/gpu-allow-multiple-allocations-partitionable/gpu-allow-multiple-allocations-partitionable.yaml
@@ -1,0 +1,87 @@
+# Example: Two Pods sharing one partition device via AllowMultipleAllocations
+# (DRAConsumableCapacity) with partitionable devices enabled. Each pod requests
+# a slice of a partition's memory and compute capacity. The driver must be
+# installed with both gpuAllowMultipleAllocations=true and
+# kubeletPlugin.gpuPartitions > 0.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-allow-multiple-allocations-partitionable
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  namespace: gpu-allow-multiple-allocations-partitionable
+  name: shared-partition-pod0
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.example.com
+        capacity:
+          requests:
+            memory: 8Gi
+            compute: "10"
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  namespace: gpu-allow-multiple-allocations-partitionable
+  name: shared-partition-pod1
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.example.com
+        capacity:
+          requests:
+            memory: 8Gi
+            compute: "10"
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: gpu-allow-multiple-allocations-partitionable
+  name: pod0
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: shared-partition-pod0
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: gpu-allow-multiple-allocations-partitionable
+  name: pod1
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: shared-partition-pod1

--- a/demo/examples/gpu-allow-multiple-allocations/README.md
+++ b/demo/examples/gpu-allow-multiple-allocations/README.md
@@ -1,0 +1,115 @@
+# GPU Allow Multiple Allocations Example
+
+## Overview
+
+This example demonstrates the **DRAConsumableCapacity** feature, which allows multiple pods to share a single GPU by consuming slices of its capacity. Each pod requests a portion of the GPU's `memory` and `compute` counters from the same physical device simultaneously.
+
+**Setup**: Two pods, each with one container, each consuming 16Gi memory and 20 compute units from the same GPU.
+
+## What This Example Shows
+
+- How to use `capacity.requests` in a ResourceClaim to consume a slice of a device's capacity
+- Multiple pods sharing a single GPU via `AllowMultipleAllocations`
+- The `DRAConsumableCapacity` feature gate in practice
+
+## GPU Allocation
+
+```mermaid
+graph TD
+    subgraph Node["Node (Physical Hardware)"]
+        subgraph GPU1["GPU 1"]
+            CAP["Capacity Pool<br/>memory: 80Gi total<br/>compute: 100 total"]
+            S1["Slice: pod0<br/>memory: 16Gi / compute: 20"]
+            S2["Slice: pod1<br/>memory: 16Gi / compute: 20"]
+            CAP -.consumes.-> S1
+            CAP -.consumes.-> S2
+        end
+    end
+
+    subgraph Pod1 [Pod 0]
+        C1(ctr0)
+    end
+    subgraph Pod2 [Pod 1]
+        C2(ctr0)
+    end
+
+    S1 --- C1
+    S2 --- C2
+
+    style Node fill:#e3f2fd,stroke:#333,stroke-width:2px,color:#000
+    style GPU1 fill:#e8f4f8,stroke:#326ce5,stroke-width:2px,color:#000
+    style CAP fill:#fff3cd,color:#000,stroke:#856404,stroke-width:2px
+    style S1 fill:#9b59b6,color:#fff,stroke:#8e44ad,stroke-width:2px
+    style S2 fill:#3498db,color:#fff,stroke:#2980b9,stroke-width:2px
+    style Pod1 stroke:#326ce5,stroke-width:2px
+    style Pod2 stroke:#326ce5,stroke-width:2px
+    style C1 fill:#d4edda,color:#000,stroke:#28a745,stroke-width:2px
+    style C2 fill:#d4edda,color:#000,stroke:#28a745,stroke-width:2px
+```
+
+## Requirements
+
+### Driver Requirements
+
+- **Profile**: gpu
+- **GPUs**: 1
+- Helm value: `gpuAllowMultipleAllocations=true`
+
+### Cluster Requirements
+
+- Kubernetes 1.35+
+- Feature gate: `DRAConsumableCapacity` (Alpha in 1.35, enabled by default in 1.36+)
+
+## Prerequisites
+
+Install the driver with multiple allocations enabled:
+
+```bash
+helm upgrade -i \
+  --create-namespace \
+  --namespace dra-example-driver \
+  --set gpuAllowMultipleAllocations=true \
+  dra-example-driver \
+  deployments/helm/dra-example-driver
+```
+
+## How to Run
+
+1. Apply the example:
+
+   ```bash
+   cd demo/examples/gpu-allow-multiple-allocations && kubectl apply -f gpu-allow-multiple-allocations.yaml
+   ```
+
+2. Verify both pods are running:
+
+   ```bash
+   kubectl get pods -n gpu-allow-multiple-allocations
+   ```
+
+3. Check GPU allocation for both pods:
+
+   ```bash
+   kubectl logs -n gpu-allow-multiple-allocations pod0 -c ctr0 | grep GPU_DEVICE
+   kubectl logs -n gpu-allow-multiple-allocations pod1 -c ctr0 | grep GPU_DEVICE
+   ```
+
+## Expected Output
+
+Both pods should show the **same** GPU ID, confirming they are sharing the same physical GPU, each consuming their requested capacity slice.
+
+Example output:
+
+```
+# Pod pod0
+GPU_DEVICE_0=gpu-0
+
+# Pod pod1
+GPU_DEVICE_0=gpu-0
+```
+
+## Cleanup
+
+```bash
+cd demo/examples/gpu-allow-multiple-allocations && kubectl delete -f gpu-allow-multiple-allocations.yaml
+```

--- a/demo/examples/gpu-allow-multiple-allocations/gpu-allow-multiple-allocations.yaml
+++ b/demo/examples/gpu-allow-multiple-allocations/gpu-allow-multiple-allocations.yaml
@@ -1,0 +1,85 @@
+# Example: Two Pods sharing one GPU via AllowMultipleAllocations (DRAConsumableCapacity).
+# Each pod requests 16Gi memory and 20 compute from the same device.
+# The driver must be installed with gpuAllowMultipleAllocations=true.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-allow-multiple-allocations
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  namespace: gpu-allow-multiple-allocations
+  name: shared-gpu-pod0
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.example.com
+        capacity:
+          requests:
+            memory: 16Gi
+            compute: "20"
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  namespace: gpu-allow-multiple-allocations
+  name: shared-gpu-pod1
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.example.com
+        capacity:
+          requests:
+            memory: 16Gi
+            compute: "20"
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: gpu-allow-multiple-allocations
+  name: pod0
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: shared-gpu-pod0
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: gpu-allow-multiple-allocations
+  name: pod1
+  labels:
+    app: pod
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: shared-gpu-pod1

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -88,6 +88,8 @@ spec:
           value: {{ .Values.kubeletPlugin.numDevices | quote }}
         - name: GPU_DEVICE_STATUS
           value: {{ .Values.gpuDeviceStatus | quote }}
+        - name: GPU_ALLOW_MULTIPLE_ALLOCATIONS
+          value: {{ .Values.gpuAllowMultipleAllocations | quote }}
         {{- if (gt (int .Values.kubeletPlugin.containers.plugin.healthcheckPort) 0) }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -34,6 +34,11 @@ deviceClass:
 # into ResourceClaim.status.devices[].data via server-side apply.
 gpuDeviceStatus: false
 
+# gpuAllowMultipleAllocations enables AllowMultipleAllocations on every GPU
+# device and attaches a RequestPolicy to each device's
+# memory capacity (DRAConsumableCapacity feature).
+gpuAllowMultipleAllocations: false
+
 imagePullSecrets: []
 image:
   repository: registry.k8s.io/dra-example-driver/dra-example-driver

--- a/internal/profiles/gpu/gpu.go
+++ b/internal/profiles/gpu/gpu.go
@@ -36,6 +36,7 @@ import (
 
 	configapi "sigs.k8s.io/dra-example-driver/api/example.com/resource/gpu/v1alpha1"
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 )
 
 const (
@@ -45,20 +46,22 @@ const (
 )
 
 type Profile struct {
-	nodeName           string
-	numGPUs            int
-	partitionsPerGPU   int
-	enableDeviceStatus bool
-	bindingConditions  bool
+	nodeName                 string
+	numGPUs                  int
+	partitionsPerGPU         int
+	enableDeviceStatus       bool
+	bindingConditions        bool
+	allowMultipleAllocations bool
 }
 
-func NewProfile(nodeName string, numGPUs int, partitionsPerGPU int, enableDeviceStatus bool, bindingConditions bool) Profile {
+func NewProfile(nodeName string, numGPUs int, partitionsPerGPU int, enableDeviceStatus bool, bindingConditions bool, allowMultipleAllocations bool) Profile {
 	return Profile{
-		nodeName:           nodeName,
-		numGPUs:            numGPUs,
-		partitionsPerGPU:   partitionsPerGPU,
-		enableDeviceStatus: enableDeviceStatus,
-		bindingConditions:  bindingConditions,
+		nodeName:                 nodeName,
+		numGPUs:                  numGPUs,
+		partitionsPerGPU:         partitionsPerGPU,
+		enableDeviceStatus:       enableDeviceStatus,
+		bindingConditions:        bindingConditions,
+		allowMultipleAllocations: allowMultipleAllocations,
 	}
 }
 
@@ -114,12 +117,12 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 				partitionAttrs["partitionable"] = resourceapi.DeviceAttribute{BoolValue: ptr.To(true)}
 
 				devices = append(devices, resourceapi.Device{
-					Name:       fmt.Sprintf("gpu-%d-partition-%d", i, j),
-					Attributes: partitionAttrs,
+					Name:                     fmt.Sprintf("gpu-%d-partition-%d", i, j),
+					Attributes:               partitionAttrs,
+					AllowMultipleAllocations: ptr.To(p.allowMultipleAllocations),
 					Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-						"memory": {
-							Value: partitionMemory,
-						},
+						"memory":  p.memoryCapacity(partitionMemory),
+						"compute": p.computeCapacity(partitionCompute),
 					},
 					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
 						{
@@ -143,12 +146,12 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 			fullAttrs["full"] = resourceapi.DeviceAttribute{BoolValue: ptr.To(true)}
 
 			devices = append(devices, resourceapi.Device{
-				Name:       fmt.Sprintf("gpu-%d-full", i),
-				Attributes: fullAttrs,
+				Name:                     fmt.Sprintf("gpu-%d-full", i),
+				Attributes:               fullAttrs,
+				AllowMultipleAllocations: ptr.To(p.allowMultipleAllocations),
 				Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-					"memory": {
-						Value: memoryPerGPU,
-					},
+					"memory":  p.memoryCapacity(memoryPerGPU),
+					"compute": p.computeCapacity(computePerGPU),
 				},
 				ConsumesCounters: []resourceapi.DeviceCounterConsumption{
 					{
@@ -166,12 +169,12 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 			})
 		} else {
 			devices = append(devices, resourceapi.Device{
-				Name:       fmt.Sprintf("gpu-%d", i),
-				Attributes: attrs,
+				Name:                     fmt.Sprintf("gpu-%d", i),
+				Attributes:               attrs,
+				AllowMultipleAllocations: ptr.To(p.allowMultipleAllocations),
 				Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-					"memory": {
-						Value: memoryPerGPU,
-					},
+					"memory":  p.memoryCapacity(memoryPerGPU),
+					"compute": p.computeCapacity(computePerGPU),
 				},
 			})
 		}
@@ -201,6 +204,60 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 	}
 
 	return resources, nil
+}
+
+// memoryCapacity builds a DeviceCapacity for a memory quantity.
+// When allowMultipleAllocations is enabled it attaches a RequestPolicy with
+// ValidRange{Min: 1Gi, Step: 1Gi, Max: value} so consumers can request any
+// 1Gi-aligned amount up to the full device memory.
+//
+// 1Gi is chosen as both the minimum and step for flexibility: when used with a
+// PartitionableDevice the number of partitions can be any number.
+// partitionMemory must be >= 1Gi.
+func (p Profile) memoryCapacity(value resource.Quantity) resourceapi.DeviceCapacity {
+	dc := resourceapi.DeviceCapacity{Value: value}
+	if p.allowMultipleAllocations {
+		min := resource.MustParse("1Gi")
+		step := resource.MustParse("1Gi")
+		defaultVal := value.DeepCopy()
+		maxVal := value.DeepCopy()
+		dc.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+			Default: &defaultVal,
+			ValidRange: &resourceapi.CapacityRequestPolicyRange{
+				Min:  &min,
+				Step: &step,
+				Max:  &maxVal,
+			},
+		}
+	}
+	return dc
+}
+
+// computeCapacity builds a DeviceCapacity for a compute quantity.
+// When allowMultipleAllocations is enabled it attaches a RequestPolicy with
+// ValidRange{Min: 1, Step: 1, Max: value} so consumers can request any
+// multiple of 1 up to the full device compute capacity.
+//
+// 1 is chosen as both the minimum and step for flexibility: when used with a
+// PartitionableDevice the number of partitions can be any number.
+// partitionCompute must be >= 1.
+func (p Profile) computeCapacity(value resource.Quantity) resourceapi.DeviceCapacity {
+	dc := resourceapi.DeviceCapacity{Value: value}
+	if p.allowMultipleAllocations {
+		min := resource.MustParse("1")
+		step := resource.MustParse("1")
+		defaultVal := value.DeepCopy()
+		maxVal := value.DeepCopy()
+		dc.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+			Default: &defaultVal,
+			ValidRange: &resourceapi.CapacityRequestPolicyRange{
+				Min:  &min,
+				Step: &step,
+				Max:  &maxVal,
+			},
+		}
+	}
+	return dc
 }
 
 func generateUUIDs(seed string, count int) []string {
@@ -299,11 +356,21 @@ func applyGpuConfig(config *configapi.GpuConfig, results []*resourceapi.DeviceRe
 			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_PARTITION_COUNT=%v", envID, spconfig.PartitionCount))
 		}
 
+		if memory, ok := result.ConsumedCapacity["memory"]; ok {
+			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_MEMORY=%s", envID, memory.String()))
+		}
+		if compute, ok := result.ConsumedCapacity["compute"]; ok {
+			envs = append(envs, fmt.Sprintf("GPU_DEVICE_%s_COMPUTE=%s", envID, compute.String()))
+		}
+
 		edits := &cdispec.ContainerEdits{
 			Env: envs,
 		}
 
-		perDeviceEdits[result.Device] = &cdiapi.ContainerEdits{ContainerEdits: edits}
+		// Key edits by the share-aware device ID so that multiple allocations
+		// of the same device (AllowMultipleAllocations) each get their own edits.
+		deviceID := helpers.GetCDIDeviceID(result.Device, (*string)(result.ShareID))
+		perDeviceEdits[deviceID] = &cdiapi.ContainerEdits{ContainerEdits: edits}
 	}
 
 	return perDeviceEdits, nil

--- a/internal/profiles/gpu/gpu_test.go
+++ b/internal/profiles/gpu/gpu_test.go
@@ -18,38 +18,43 @@ package gpu
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
 )
 
 func TestNewProfile(t *testing.T) {
-	profile := NewProfile("test-node", 4, 0, false, false)
+	profile := NewProfile("test-node", 4, 0, false, false, false)
 
 	assert.Equal(t, "test-node", profile.nodeName)
 	assert.Equal(t, 4, profile.numGPUs)
 	assert.Equal(t, 0, profile.partitionsPerGPU)
 	assert.False(t, profile.enableDeviceStatus)
 	assert.Equal(t, false, profile.bindingConditions)
+	assert.Equal(t, false, profile.allowMultipleAllocations)
 }
 
 func TestNewProfile_WithAllOptions(t *testing.T) {
-	profile := NewProfile("test-node", 2, 4, false, true)
+	profile := NewProfile("test-node", 2, 4, false, true, true)
 
 	assert.Equal(t, "test-node", profile.nodeName)
 	assert.Equal(t, 2, profile.numGPUs)
 	assert.Equal(t, 4, profile.partitionsPerGPU)
 	assert.Equal(t, true, profile.bindingConditions)
+	assert.Equal(t, true, profile.allowMultipleAllocations)
 }
 
 func TestEnumerateDevices_Standard(t *testing.T) {
-	profile := NewProfile("test-node", 2, 0, false, false)
+	profile := NewProfile("test-node", 2, 0, false, false, false)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -84,15 +89,57 @@ func TestEnumerateDevices_Standard(t *testing.T) {
 		assert.NotNil(t, device.Attributes["model"].StringValue)
 		assert.Equal(t, "LATEST-GPU-MODEL", *device.Attributes["model"].StringValue)
 
-		// Verify capacity
+		// AllowMultipleAllocations should be false (not enabled)
+		require.NotNil(t, device.AllowMultipleAllocations)
+		assert.False(t, *device.AllowMultipleAllocations)
+
+		// No RequestPolicy when allowMultipleAllocations is disabled
 		memoryKey := resourceapi.QualifiedName("memory")
 		assert.Contains(t, device.Capacity, memoryKey)
 		assert.Equal(t, resource.MustParse("80Gi"), device.Capacity[memoryKey].Value)
+		assert.Nil(t, device.Capacity[memoryKey].RequestPolicy)
+
+		computeKey := resourceapi.QualifiedName("compute")
+		assert.Contains(t, device.Capacity, computeKey)
+		assert.Equal(t, resource.MustParse("100"), device.Capacity[computeKey].Value)
+		assert.Nil(t, device.Capacity[computeKey].RequestPolicy)
 	}
 }
 
+func TestEnumerateDevices_AllowMultipleAllocations(t *testing.T) {
+	profile := NewProfile("test-node", 1, 0, false, false, true)
+
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	device := resources.Pools["test-node"].Slices[0].Devices[0]
+
+	require.NotNil(t, device.AllowMultipleAllocations)
+	assert.True(t, *device.AllowMultipleAllocations)
+
+	// memory: ValidRange{Min: 1Gi, Step: 1Gi, Max: 80Gi}, Default: 80Gi
+	memoryCap := device.Capacity[resourceapi.QualifiedName("memory")]
+	assert.Equal(t, resource.MustParse("80Gi"), memoryCap.Value)
+	require.NotNil(t, memoryCap.RequestPolicy)
+	assert.Equal(t, resource.MustParse("80Gi"), *memoryCap.RequestPolicy.Default)
+	require.NotNil(t, memoryCap.RequestPolicy.ValidRange)
+	assert.Equal(t, resource.MustParse("1Gi"), *memoryCap.RequestPolicy.ValidRange.Min)
+	assert.Equal(t, resource.MustParse("1Gi"), *memoryCap.RequestPolicy.ValidRange.Step)
+	assert.Equal(t, resource.MustParse("80Gi"), *memoryCap.RequestPolicy.ValidRange.Max)
+
+	// compute: ValidRange{Min: 1, Step: 1, Max: 100}, Default: 100
+	computeCap := device.Capacity[resourceapi.QualifiedName("compute")]
+	assert.Equal(t, resource.MustParse("100"), computeCap.Value)
+	require.NotNil(t, computeCap.RequestPolicy)
+	assert.Equal(t, resource.MustParse("100"), *computeCap.RequestPolicy.Default)
+	require.NotNil(t, computeCap.RequestPolicy.ValidRange)
+	assert.Equal(t, resource.MustParse("1"), *computeCap.RequestPolicy.ValidRange.Min)
+	assert.Equal(t, resource.MustParse("1"), *computeCap.RequestPolicy.ValidRange.Step)
+	assert.Equal(t, resource.MustParse("100"), *computeCap.RequestPolicy.ValidRange.Max)
+}
+
 func TestEnumerateDevices_Partitionable(t *testing.T) {
-	profile := NewProfile("test-node", 2, 4, false, false)
+	profile := NewProfile("test-node", 2, 4, false, false, false)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -138,7 +185,7 @@ func TestEnumerateDevices_Partitionable(t *testing.T) {
 }
 
 func TestEnumerateDevices_PartitionableDeviceAttributes(t *testing.T) {
-	profile := NewProfile("test-node", 1, 2, false, false)
+	profile := NewProfile("test-node", 1, 2, false, false, false)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -189,10 +236,91 @@ func TestEnumerateDevices_PartitionableDeviceAttributes(t *testing.T) {
 	assert.Equal(t, resource.MustParse("100"), fullDevice.ConsumesCounters[0].Counters["compute"].Value)
 }
 
+func TestEnumerateDevices_AllowMultipleAllocations_AndPartitions(t *testing.T) {
+	profile := NewProfile("test-node", 1, 2, false, false, true)
+
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	pool := resources.Pools["test-node"]
+
+	// Two slices: counter slice + device slice
+	require.Len(t, pool.Slices, 2)
+	deviceSlice := pool.Slices[1]
+
+	// 2 partition devices + 1 full device
+	require.Len(t, deviceSlice.Devices, 3)
+
+	// Partition devices: AllowMultipleAllocations=true + RequestPolicy scoped to partition size
+	for i := 0; i < 2; i++ {
+		device := deviceSlice.Devices[i]
+		assert.Equal(t, fmt.Sprintf("gpu-0-partition-%d", i), device.Name)
+
+		require.NotNil(t, device.AllowMultipleAllocations)
+		assert.True(t, *device.AllowMultipleAllocations)
+
+		// memory capacity: Value=40Gi, RequestPolicy{Default:40Gi, ValidRange{Min:1Gi,Step:1Gi,Max:40Gi}}
+		memoryCap := device.Capacity[resourceapi.QualifiedName("memory")]
+		assert.Equal(t, resource.MustParse("40Gi"), memoryCap.Value)
+		require.NotNil(t, memoryCap.RequestPolicy)
+		assert.Equal(t, resource.MustParse("40Gi"), *memoryCap.RequestPolicy.Default)
+		require.NotNil(t, memoryCap.RequestPolicy.ValidRange)
+		assert.Equal(t, resource.MustParse("1Gi"), *memoryCap.RequestPolicy.ValidRange.Min)
+		assert.Equal(t, resource.MustParse("1Gi"), *memoryCap.RequestPolicy.ValidRange.Step)
+		assert.Equal(t, resource.MustParse("40Gi"), *memoryCap.RequestPolicy.ValidRange.Max)
+
+		// compute capacity: Value=50, RequestPolicy{Default:50, ValidRange{Min:1,Step:1,Max:50}}
+		fifty := resource.MustParse("50")
+		computeCap := device.Capacity[resourceapi.QualifiedName("compute")]
+		assert.Equal(t, fifty.Value(), computeCap.Value.Value())
+		require.NotNil(t, computeCap.RequestPolicy)
+		assert.Equal(t, fifty.Value(), computeCap.RequestPolicy.Default.Value())
+		require.NotNil(t, computeCap.RequestPolicy.ValidRange)
+		assert.Equal(t, resource.MustParse("1"), *computeCap.RequestPolicy.ValidRange.Min)
+		assert.Equal(t, resource.MustParse("1"), *computeCap.RequestPolicy.ValidRange.Step)
+		assert.Equal(t, fifty.Value(), computeCap.RequestPolicy.ValidRange.Max.Value())
+
+		// ConsumesCounters still present
+		require.Len(t, device.ConsumesCounters, 1)
+		assert.Equal(t, "gpu-0-counters", device.ConsumesCounters[0].CounterSet)
+	}
+
+	// Full device: AllowMultipleAllocations=true + RequestPolicy scoped to full GPU size
+	fullDevice := deviceSlice.Devices[2]
+	assert.Equal(t, "gpu-0-full", fullDevice.Name)
+
+	require.NotNil(t, fullDevice.AllowMultipleAllocations)
+	assert.True(t, *fullDevice.AllowMultipleAllocations)
+
+	// memory capacity: Value=80Gi, RequestPolicy{Default:80Gi, ValidRange{Min:1Gi,Step:1Gi,Max:80Gi}}
+	fullMemoryCap := fullDevice.Capacity[resourceapi.QualifiedName("memory")]
+	assert.Equal(t, resource.MustParse("80Gi"), fullMemoryCap.Value)
+	require.NotNil(t, fullMemoryCap.RequestPolicy)
+	assert.Equal(t, resource.MustParse("80Gi"), *fullMemoryCap.RequestPolicy.Default)
+	require.NotNil(t, fullMemoryCap.RequestPolicy.ValidRange)
+	assert.Equal(t, resource.MustParse("1Gi"), *fullMemoryCap.RequestPolicy.ValidRange.Min)
+	assert.Equal(t, resource.MustParse("1Gi"), *fullMemoryCap.RequestPolicy.ValidRange.Step)
+	assert.Equal(t, resource.MustParse("80Gi"), *fullMemoryCap.RequestPolicy.ValidRange.Max)
+
+	// compute capacity: Value=100, RequestPolicy{Default:100, ValidRange{Min:1,Step:1,Max:100}}
+	fullComputeCap := fullDevice.Capacity[resourceapi.QualifiedName("compute")]
+	assert.Equal(t, resource.MustParse("100"), fullComputeCap.Value)
+	require.NotNil(t, fullComputeCap.RequestPolicy)
+	assert.Equal(t, resource.MustParse("100"), *fullComputeCap.RequestPolicy.Default)
+	require.NotNil(t, fullComputeCap.RequestPolicy.ValidRange)
+	assert.Equal(t, resource.MustParse("1"), *fullComputeCap.RequestPolicy.ValidRange.Min)
+	assert.Equal(t, resource.MustParse("1"), *fullComputeCap.RequestPolicy.ValidRange.Step)
+	assert.Equal(t, resource.MustParse("100"), *fullComputeCap.RequestPolicy.ValidRange.Max)
+
+	// ConsumesCounters still present
+	require.Len(t, fullDevice.ConsumesCounters, 1)
+	assert.Equal(t, "gpu-0-counters", fullDevice.ConsumesCounters[0].CounterSet)
+}
+
 func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
 	// UUIDs should be consistent for the same node name
-	profile1 := NewProfile("test-node", 2, 0, false, false)
-	profile2 := NewProfile("test-node", 2, 0, false, false)
+	profile1 := NewProfile("test-node", 2, 0, false, false, false)
+	profile2 := NewProfile("test-node", 2, 0, false, false, false)
 
 	resources1, err := profile1.EnumerateDevices()
 	require.NoError(t, err)
@@ -210,8 +338,8 @@ func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
 }
 
 func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
-	profile1 := NewProfile("node-1", 1, 0, false, false)
-	profile2 := NewProfile("node-2", 1, 0, false, false)
+	profile1 := NewProfile("node-1", 1, 0, false, false, false)
+	profile2 := NewProfile("node-2", 1, 0, false, false, false)
 
 	resources1, err := profile1.EnumerateDevices()
 	require.NoError(t, err)
@@ -225,9 +353,9 @@ func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
 }
 
 func TestBuildDeviceStatus_Disabled(t *testing.T) {
-	var _ profiles.DeviceStatusBuilder = NewProfile("test-node", 1, 0, true, false)
+	var _ profiles.DeviceStatusBuilder = NewProfile("test-node", 1, 0, true, false, false)
 
-	profile := NewProfile("test-node", 1, 0, false, false)
+	profile := NewProfile("test-node", 1, 0, false, false, false)
 	allocatable := map[string]resourceapi.Device{
 		"gpu-0": {Name: "gpu-0"},
 	}
@@ -242,7 +370,7 @@ func TestBuildDeviceStatus_Disabled(t *testing.T) {
 }
 
 func TestBuildDeviceStatus_Enabled(t *testing.T) {
-	profile := NewProfile("test-node", 1, 0, true, false)
+	profile := NewProfile("test-node", 1, 0, true, false, false)
 	allocatable := map[string]resourceapi.Device{
 		"gpu-0": {
 			Name: "gpu-0",
@@ -278,7 +406,7 @@ func TestBuildDeviceStatus_Enabled(t *testing.T) {
 }
 
 func TestBuildDeviceStatus_UnknownDevice(t *testing.T) {
-	profile := NewProfile("test-node", 1, 0, true, false)
+	profile := NewProfile("test-node", 1, 0, true, false, false)
 	result := &resourceapi.DeviceRequestAllocationResult{
 		Device: "gpu-0",
 		Driver: "gpu.example.com",
@@ -294,4 +422,74 @@ func TestBuildDeviceStatus_UnknownDevice(t *testing.T) {
 	var data map[string]resourceapi.DeviceAttribute
 	require.NoError(t, json.Unmarshal(got.Data.Raw, &data))
 	assert.Empty(t, data)
+}
+
+func TestApplyConfig(t *testing.T) {
+	profile := NewProfile("test-node", 2, 0, false, false, false)
+
+	tests := []struct {
+		name     string
+		config   runtime.Object
+		results  []*resourceapi.DeviceRequestAllocationResult
+		wantEnvs map[string][]string
+	}{
+		{
+			name:   "consumed memory and compute capacity",
+			config: nil,
+			results: []*resourceapi.DeviceRequestAllocationResult{
+				{
+					Device: "gpu-0",
+					ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+						"memory":  resource.MustParse("16Gi"),
+						"compute": resource.MustParse("50"),
+					},
+				},
+			},
+			wantEnvs: map[string][]string{
+				"gpu-0": {
+					"GPU_DEVICE_0=gpu-0",
+					"GPU_DEVICE_0_SHARING_STRATEGY=TimeSlicing",
+					"GPU_DEVICE_0_TIMESLICE_INTERVAL=Default",
+					"GPU_DEVICE_0_MEMORY=16Gi",
+					"GPU_DEVICE_0_COMPUTE=50",
+				},
+			},
+		},
+		{
+			name:   "AllowMultipleAllocations: edits are keyed by device+shareID",
+			config: nil,
+			results: []*resourceapi.DeviceRequestAllocationResult{
+				{
+					Device:  "gpu-0",
+					ShareID: ptr.To(types.UID("share-abc")),
+					ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+						"memory":  resource.MustParse("16Gi"),
+						"compute": resource.MustParse("20"),
+					},
+				},
+			},
+			// state.go looks up edits by helpers.GetCDIDeviceID = "gpu-0-share-abc"
+			wantEnvs: map[string][]string{
+				"gpu-0-share-abc": {
+					"GPU_DEVICE_0=gpu-0",
+					"GPU_DEVICE_0_SHARING_STRATEGY=TimeSlicing",
+					"GPU_DEVICE_0_TIMESLICE_INTERVAL=Default",
+					"GPU_DEVICE_0_MEMORY=16Gi",
+					"GPU_DEVICE_0_COMPUTE=20",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			edits, err := profile.ApplyConfig(tt.config, tt.results)
+			require.NoError(t, err)
+
+			for device, wantEnv := range tt.wantEnvs {
+				require.Contains(t, edits, device)
+				assert.ElementsMatch(t, wantEnv, edits[device].Env)
+			}
+		})
+	}
 }

--- a/test/e2e/driver_test.go
+++ b/test/e2e/driver_test.go
@@ -87,6 +87,11 @@ type DriverConfig struct {
 	// attributes (e.g. uuid, model, driverVersion) into
 	// ResourceClaim.status.devices[].data.
 	GPUDeviceStatus bool
+
+	// GPUAllowMultipleAllocations, when true, sets AllowMultipleAllocations on
+	// every GPU device and adds a RequestPolicy (ValidRange) to memory and
+	// compute capacities (DRAConsumableCapacity feature).
+	GPUAllowMultipleAllocations bool
 }
 
 // installedDriver is what installDriver returns: the identity bits downstream
@@ -157,9 +162,10 @@ func installDriver(ctx context.Context, cfg DriverConfig) installedDriver {
 func buildHelmValues(cfg DriverConfig, namespace string) map[string]any {
 	GinkgoHelper()
 	values := map[string]any{
-		"driverName":        cfg.DriverName,
-		"namespaceOverride": namespace,
-		"gpuDeviceStatus":   cfg.GPUDeviceStatus,
+		"driverName":                  cfg.DriverName,
+		"namespaceOverride":           namespace,
+		"gpuDeviceStatus":             cfg.GPUDeviceStatus,
+		"gpuAllowMultipleAllocations": cfg.GPUAllowMultipleAllocations,
 		"kubeletPlugin": map[string]any{
 			"numDevices": cfg.NumDevices,
 		},
@@ -260,9 +266,15 @@ func readPodLogs(ctx context.Context, namespace, pod, container string, tailLine
 
 // waitForDriverReady polls for signals that Helm --wait does not cover: the
 // kubelet plugin DaemonSet has ready pods, the DeviceClass exists,
-// ResourceSlices have been published, and (when webhookEnabled) the webhook
-// is serving. The DaemonSet check ties readiness to the current install so
-// stale cluster state can't false-positive.
+// ResourceSlices with at least one device have been published, and (when
+// webhookEnabled) the webhook is serving. The DaemonSet check ties readiness
+// to the current install so stale cluster state can't false-positive.
+//
+// Checking for at least one device (not just any ResourceSlice) is important
+// for partitionable-device configurations: the driver publishes a counters-only
+// slice first, followed by a separate devices slice. Returning as soon as the
+// counters slice appears would cause tests to run before partition devices are
+// visible.
 func waitForDriverReady(ctx context.Context, namespace, driverName string, webhookEnabled bool) {
 	GinkgoHelper()
 
@@ -294,6 +306,17 @@ func waitForDriverReady(ctx context.Context, namespace, driverName string, webho
 			"Failed to list ResourceSlices for driver %s", driverName)
 		g.Expect(slices.Items).NotTo(BeEmpty(),
 			"No ResourceSlices yet published for driver %s", driverName)
+
+		// Ensure at least one device has been published. For partitionable
+		// drivers the first slice to arrive is counters-only; the devices
+		// slice follows shortly after. Gating on a device being present
+		// prevents tests from running against an incomplete slice set.
+		var totalDevices int
+		for _, s := range slices.Items {
+			totalDevices += len(s.Spec.Devices)
+		}
+		g.Expect(totalDevices).To(BeNumerically(">", 0),
+			"ResourceSlices for driver %s exist but contain no devices yet", driverName)
 	}).WithContext(ctx).WithTimeout(driverInstallTimeout).WithPolling(2 * time.Second).Should(Succeed())
 
 	if webhookEnabled {

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -852,3 +852,145 @@ func verifyNetDeviceAllocation(ctx context.Context, namespace, podName, containe
 			namespace, podName, containerName, matches)
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
 }
+
+// verifyResourceSliceAllowMultipleAllocations verifies that all devices
+// published by the given driver have AllowMultipleAllocations=true and carry
+// a RequestPolicy with a ValidRange on both "memory" and "compute" capacities.
+func verifyResourceSliceAllowMultipleAllocations(ctx context.Context, driverName string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		slices, err := clientset.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
+			FieldSelector: "spec.driver=" + driverName,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(slices.Items).NotTo(BeEmpty(), "no ResourceSlices found for driver %s", driverName)
+
+		totalDevices := 0
+		for _, slice := range slices.Items {
+			for _, device := range slice.Spec.Devices {
+				totalDevices++
+				g.Expect(device.AllowMultipleAllocations).NotTo(BeNil(),
+					"device %s in ResourceSlice %s: AllowMultipleAllocations is nil", device.Name, slice.Name)
+				g.Expect(*device.AllowMultipleAllocations).To(BeTrue(),
+					"device %s in ResourceSlice %s: AllowMultipleAllocations should be true", device.Name, slice.Name)
+
+				for _, capName := range []resourceapi.QualifiedName{"memory", "compute"} {
+					cap, ok := device.Capacity[capName]
+					g.Expect(ok).To(BeTrue(),
+						"device %s in ResourceSlice %s: missing %q capacity", device.Name, slice.Name, capName)
+					g.Expect(cap.RequestPolicy).NotTo(BeNil(),
+						"device %s capacity %q: RequestPolicy should be set", device.Name, capName)
+					g.Expect(cap.RequestPolicy.ValidRange).NotTo(BeNil(),
+						"device %s capacity %q: RequestPolicy.ValidRange should be set", device.Name, capName)
+					g.Expect(cap.RequestPolicy.ValidRange.Min).NotTo(BeNil(),
+						"device %s capacity %q: RequestPolicy.ValidRange.Min should be set", device.Name, capName)
+					g.Expect(cap.RequestPolicy.ValidRange.Step).NotTo(BeNil(),
+						"device %s capacity %q: RequestPolicy.ValidRange.Step should be set", device.Name, capName)
+					g.Expect(cap.RequestPolicy.ValidRange.Max).NotTo(BeNil(),
+						"device %s capacity %q: RequestPolicy.ValidRange.Max should be set", device.Name, capName)
+					fmt.Fprintf(GinkgoWriter,
+						"device %s capacity %q: value=%s min=%s step=%s max=%s\n",
+						device.Name, capName, cap.Value.String(),
+						cap.RequestPolicy.ValidRange.Min.String(),
+						cap.RequestPolicy.ValidRange.Step.String(),
+						cap.RequestPolicy.ValidRange.Max.String(),
+					)
+				}
+			}
+		}
+		g.Expect(totalDevices).To(BeNumerically(">", 0),
+			"driver %s: no devices found across %d ResourceSlice(s); devices slice may not have been published yet",
+			driverName, len(slices.Items))
+	}, "30s", "2s").Should(Succeed())
+}
+
+// verifyGPUConsumedCapacity verifies that two pods sharing a GPU each have a
+// distinct non-empty ShareID and that ConsumedCapacity is reported for both
+// "memory" and "compute" on every allocation result. It also checks that the
+// driver injected GPU_DEVICE_<ID>_MEMORY and GPU_DEVICE_<ID>_COMPUTE env vars
+// into the container.
+func verifyGPUConsumedCapacity(ctx context.Context, namespace, driverName string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pods.Items).NotTo(BeEmpty(), "no pods in namespace %s", namespace)
+
+		seenShareIDs := map[string]string{} // shareID -> pod name
+
+		for _, pod := range pods.Items {
+			// Pods that reference ResourceClaims directly (via resourceClaimName)
+			// do not get ResourceClaimStatuses populated by the kubelet — only
+			// template-created claims produce that status field. Resolve claim
+			// names from pod.Spec.ResourceClaims instead.
+			g.Expect(pod.Spec.ResourceClaims).NotTo(BeEmpty(),
+				"pod %s has no spec.resourceClaims", pod.Name)
+
+			// Fetch pod logs once per pod to verify injected env vars.
+			gpus, logs := getGPUsFromPodLogs(ctx, g, namespace, pod.Name, "ctr0")
+			g.Expect(gpus).NotTo(BeEmpty(), "pod %s: no GPU env vars found in logs", pod.Name)
+			gpuID := getGPUID(gpus[0])
+
+			for _, prc := range pod.Spec.ResourceClaims {
+				g.Expect(prc.ResourceClaimName).NotTo(BeNil(),
+					"pod %s resourceClaim %s: ResourceClaimName is nil", pod.Name, prc.Name)
+				claimName := *prc.ResourceClaimName
+				claim, err := clientset.ResourceV1().ResourceClaims(namespace).Get(
+					ctx, claimName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// ShareID and ConsumedCapacity both live on the allocation results
+				// (status.allocation.devices.results), not on status.devices.
+				// status.devices is only populated when the driver calls BuildDeviceStatus
+				// (GPUDeviceStatus=true), which is not enabled in this test.
+				g.Expect(claim.Status.Allocation).NotTo(BeNil(),
+					"ResourceClaim %s has no status.allocation", claimName)
+				g.Expect(claim.Status.Allocation.Devices.Results).NotTo(BeEmpty(),
+					"ResourceClaim %s has no status.allocation.devices.results", claimName)
+
+				for _, r := range claim.Status.Allocation.Devices.Results {
+					// Each share must carry a non-empty ShareID.
+					g.Expect(r.ShareID).NotTo(BeNil(),
+						"claim %s device %s: ShareID should be set", claimName, r.Device)
+					shareID := string(*r.ShareID)
+					g.Expect(shareID).NotTo(BeEmpty(),
+						"claim %s device %s: ShareID should not be empty", claimName, r.Device)
+
+					// ShareIDs must be distinct across pods.
+					if prev, exists := seenShareIDs[shareID]; exists {
+						g.Expect(prev).To(Equal(pod.Name),
+							"ShareID %s is shared between pods %s and %s", shareID, prev, pod.Name)
+					}
+					seenShareIDs[shareID] = pod.Name
+
+					g.Expect(r.ConsumedCapacity).NotTo(BeEmpty(),
+						"claim %s device %s: ConsumedCapacity should not be empty", claimName, r.Device)
+					for _, capName := range []resourceapi.QualifiedName{"memory", "compute"} {
+						qty, ok := r.ConsumedCapacity[capName]
+						g.Expect(ok).To(BeTrue(),
+							"claim %s device %s: ConsumedCapacity missing %q", claimName, r.Device, capName)
+						g.Expect(qty.IsZero()).To(BeFalse(),
+							"claim %s device %s: ConsumedCapacity[%q] should be non-zero", claimName, r.Device, capName)
+						fmt.Fprintf(GinkgoWriter, "pod %s claim %s device %s: consumed %s=%s\n",
+							pod.Name, claimName, r.Device, capName, qty.String())
+					}
+				}
+			}
+
+			// Verify that GPU_DEVICE_<ID>_MEMORY and GPU_DEVICE_<ID>_COMPUTE were
+			// injected into the container by the driver.
+			memoryEnv := extractGPUProperty(logs, gpuID, "MEMORY")
+			g.Expect(memoryEnv).NotTo(BeEmpty(),
+				"pod %s: GPU_DEVICE_%s_MEMORY env var not found in container logs", pod.Name, gpuID)
+			computeEnv := extractGPUProperty(logs, gpuID, "COMPUTE")
+			g.Expect(computeEnv).NotTo(BeEmpty(),
+				"pod %s: GPU_DEVICE_%s_COMPUTE env var not found in container logs", pod.Name, gpuID)
+			fmt.Fprintf(GinkgoWriter, "pod %s: GPU_DEVICE_%s_MEMORY=%s GPU_DEVICE_%s_COMPUTE=%s\n",
+				pod.Name, gpuID, memoryEnv, gpuID, computeEnv)
+		}
+
+		// All pods must have received distinct ShareIDs.
+		g.Expect(seenShareIDs).To(HaveLen(len(pods.Items)),
+			"expected %d distinct ShareIDs, got %v", len(pods.Items), seenShareIDs)
+	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -296,6 +296,51 @@ var _ = Describe("Test GPU allocation", func() {
 		}
 	})
 
+	Context("AllowMultipleAllocations", Ordered, func() {
+		var drv installedDriver
+
+		BeforeAll(func(ctx SpecContext) {
+			drv = installDriver(ctx, DriverConfig{
+				GPUAllowMultipleAllocations: true,
+			})
+		})
+
+		It("should publish AllowMultipleAllocations and RequestPolicy on devices in ResourceSlices", func(ctx SpecContext) {
+			verifyResourceSliceAllowMultipleAllocations(ctx, drv.DriverName)
+		})
+
+		It("should allocate two shares of the same GPU with distinct ShareIDs and ConsumedCapacity", func(ctx SpecContext) {
+			namespace := "gpu-allow-multiple-allocations"
+			deployManifest(ctx, namespace, "gpu-allow-multiple-allocations.yaml", drv)
+			checkPodsReadyAndRunning(ctx, namespace, []string{"pod0", "pod1"})
+			verifyGPUConsumedCapacity(ctx, namespace, drv.DriverName)
+		})
+
+		Context("with partitionable devices", Ordered, func() {
+			var partDrv installedDriver
+
+			BeforeAll(func(ctx SpecContext) {
+				partDrv = installDriver(ctx, DriverConfig{
+					GPUAllowMultipleAllocations: true,
+					ExtraValues: map[string]string{
+						"kubeletPlugin.gpuPartitions": "4",
+					},
+				})
+			})
+
+			It("should publish AllowMultipleAllocations and RequestPolicy on partition devices in ResourceSlices", func(ctx SpecContext) {
+				verifyResourceSliceAllowMultipleAllocations(ctx, partDrv.DriverName)
+			})
+
+			It("should allocate two shares of the same partition with distinct ShareIDs and ConsumedCapacity", func(ctx SpecContext) {
+				namespace := "gpu-allow-multiple-allocations-partitionable"
+				deployManifest(ctx, namespace, "gpu-allow-multiple-allocations-partitionable.yaml", partDrv)
+				checkPodsReadyAndRunning(ctx, namespace, []string{"pod0", "pod1"})
+				verifyGPUConsumedCapacity(ctx, namespace, partDrv.DriverName)
+			})
+		})
+	})
+
 	It("should allocate partition devices from shared GPU counters", func(ctx SpecContext) {
 		drv := installDriver(ctx, DriverConfig{
 			ExtraValues: map[string]string{


### PR DESCRIPTION
This PR implements the idea of issue #235  to extend GPU profile for showcasing consumable capacity feature with a boolean flag in configuration.

The device in resourceslices will be as below:

```yaml
    - allowMultipleAllocations: true
      attributes:
        driverVersion:
          version: 1.0.0
        index:
          int: 1
        model:
          string: LATEST-GPU-MODEL
        uuid:
          string: gpu-93d37703-997c-c46f-a531-755e3e0dc2ac
      capacity:
        compute:
          requestPolicy:
            default: "100"
            validRange:
              max: "100"
              min: "10"
              step: "10"
          value: "100"
        memory:
          requestPolicy:
            default: 80Gi
            validRange:
              max: 80Gi
              min: 8Gi
              step: 8Gi
          value: 80Gi
```

Example claim status

```yaml
      devices:
        results:
        - consumedCapacity:
            compute: "20"
            memory: 16Gi
          device: gpu-0
          driver: dra-mbqhhk.example.com
          pool: dra-example-driver-cluster-worker
          request: gpu
          shareID: 6de5d941-c79d-4a8a-ba10-668351620525
```

With partitionableDevice

```yaml
    ...
    - allowMultipleAllocations: true
      attributes:
        driverVersion:
          version: 1.0.0
        index:
          int: 1
        model:
          string: LATEST-GPU-MODEL
        partition:
          int: 1
        partitionable:
          bool: true
        uuid:
          string: gpu-93d37703-997c-c46f-a531-755e3e0dc2ac
      capacity:
        compute:
          requestPolicy:
            default: "25"
            validRange:
              max: "25"
              min: "1"
              step: "1"
          value: "25"
        memory:
          requestPolicy:
            default: 20Gi
            validRange:
              max: 20Gi
              min: 1Gi
              step: 1Gi
          value: 20Gi
      consumesCounters:
      - counterSet: gpu-1-counters
        counters:
          compute:
            value: "25"
          memory:
            value: 20Gi
      name: gpu-1-partition-1
      ...
```

Closes #235 