### PR TITLE
feat: add experimental minikube support (issue #195)

### DIFF
--- a/.github/workflows/e2e-minikube.yaml
+++ b/.github/workflows/e2e-minikube.yaml
@@ -1,0 +1,33 @@
+name: Run e2e tests (minikube)
+
+on: [ push, pull_request ]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-minikube:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: 1.26.2
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Build
+      run: make PREFIX=artifacts cmds
+    - name: install helm and kubectl
+      run: |
+        sudo snap install helm --classic
+        sudo snap install kubectl --classic
+    - name: install minikube
+      run: |
+        curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+        sudo dpkg -i minikube_latest_amd64.deb
+    - name: Setup e2e
+      run: make setup-e2e-minikube
+    - name: run e2e test
+      run: make test-e2e
+    - name: teardown e2e test
+      run: make teardown-e2e-minikube

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,12 @@ test-e2e:
 teardown-e2e:
 	test/e2e/teardown-e2e.sh
 
+setup-e2e-minikube:
+	test/e2e/setup-e2e-minikube.sh
+
+teardown-e2e-minikube:
+	test/e2e/teardown-e2e-minikube.sh
+
 # Generate an image for containerized builds
 # Note: This image is local only
 .PHONY: .build-image

--- a/README.md
+++ b/README.md
@@ -323,9 +323,10 @@ metadata:
 #### Other platforms
 This demo uses kind by default. Additional platform-specific setup and cleanup
 guides are documented in [`demo/clusters`](demo/clusters/README.md), including
-GKE instructions in [`demo/clusters/gke`](demo/clusters/gke/README.md).
+Minikube instructions in [`demo/clusters/minikube`](demo/clusters/minikube/README.md)
+and GKE instructions in [`demo/clusters/gke`](demo/clusters/gke/README.md).
 
-### Run example workloads (shared across kind and GKE)
+### Run example workloads
 Next, deploy four example apps that demonstrate how `ResourceClaim`s,
 `ResourceClaimTemplate`s, and custom `GpuConfig` objects can be used to
 select and configure resources in various ways:
@@ -469,7 +470,9 @@ kind cluster started previously:
 ```
 
 #### Other platforms
-Use the cleanup steps documented in [`demo/clusters`](demo/clusters/README.md).
+Use the cleanup steps documented in [`demo/clusters`](demo/clusters/README.md)
+for Minikube (`./demo/clusters/minikube/delete-cluster.sh`) and GKE
+(`./demo/clusters/gke/delete-cluster.sh`).
 
 ## Device Profiles
 

--- a/demo/clusters/README.md
+++ b/demo/clusters/README.md
@@ -11,3 +11,11 @@ common layout:
 - `delete-cluster.sh` — delete that cluster
 
 Platforms may add other scripts or notes next to these entrypoints as needed.
+
+## Supported platforms
+
+| Platform | Directory | Notes |
+|----------|-----------|-------|
+| [kind](https://kind.sigs.k8s.io/) | [`kind/`](kind/) | Default for local development |
+| [Minikube](https://minikube.sigs.k8s.io/) | [`minikube/`](minikube/README.md) | Local alternative to kind |
+| [GKE](https://cloud.google.com/kubernetes-engine) | [`gke/`](gke/README.md) | Managed cloud cluster |

--- a/demo/clusters/minikube/README.md
+++ b/demo/clusters/minikube/README.md
@@ -1,0 +1,67 @@
+# Running the demo on Minikube
+
+Use the helper scripts in this directory to create or delete a minikube cluster.
+
+## Prerequisites
+
+- [minikube v1.33.0+](https://minikube.sigs.k8s.io/docs/start/)
+- [docker v20.10+](https://docs.docker.com/engine/install/) (used as the minikube driver)
+- [helm v3.7.0+](https://helm.sh/docs/intro/install/)
+- [kubectl v1.18+](https://kubernetes.io/docs/reference/kubectl/)
+
+The steps below were validated with:
+- minikube: `v1.36.0`
+- Kubernetes: `v1.32.0`
+- Driver/chart release: `0.3.0`
+
+## Create cluster
+
+```bash
+./demo/clusters/minikube/create-cluster.sh
+```
+
+Supported environment variables:
+
+- `MINIKUBE_CLUSTER_NAME` (default: `dra-example-driver-cluster`)
+- `MINIKUBE_DRIVER` (default: auto-detected — `docker` if available, otherwise `podman`)
+
+The script starts a minikube cluster with:
+- `containerd` as the container runtime (required for CDI support)
+- the auto-detected container tool (`docker` or `podman`) as the minikube driver
+- Kubernetes version pinned to match `KIND_K8S_TAG` from `demo/scripts/common.sh`
+- 4 CPUs (required for the native-resource-request e2e test which requests 2 CPUs)
+- `flannel` as the CNI plugin
+- the same DRA feature gates as the Kind cluster configuration
+- CDI enabled in the containerd configuration
+
+## Build and load the driver image
+
+Build the driver image locally and load it into the minikube cluster:
+
+```bash
+./demo/build-driver.sh
+```
+
+> **Note**: `demo/build-driver.sh` only auto-loads into a kind cluster. For
+> minikube, the `create-cluster.sh` script above handles the initial load. To
+> reload after a rebuild, run:
+>
+> ```bash
+> ./demo/scripts/load-driver-image-into-minikube.sh
+> ```
+
+## Install driver
+
+```bash
+helm upgrade -i \
+  --create-namespace \
+  --namespace dra-example-driver \
+  dra-example-driver \
+  deployments/helm/dra-example-driver
+```
+
+## Delete cluster
+
+```bash
+./demo/clusters/minikube/delete-cluster.sh
+```

--- a/demo/clusters/minikube/create-cluster.sh
+++ b/demo/clusters/minikube/create-cluster.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates a minikube cluster for the demo with CDI support enabled.
+# See demo/scripts/common.sh for configuration (cluster name, etc.).
+
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/../../scripts/common.sh"
+
+# minikube only honours the last --extra-config flag for a given key. Since
+# feature-gates is a single key per component, all gates must be passed as one
+# comma-separated value rather than as repeated --extra-config flags for the
+# same component.
+FEATURE_GATES="DynamicResourceAllocation=true,DRAAdminAccess=true,DRAWorkloadResourceClaims=true,GangScheduling=true,GenericWorkload=true,DRAExtendedResource=true,DRADeviceBindingConditions=true,DRANodeAllocatableResources=true,DRAConsumableCapacity=true"
+
+${MINIKUBE} start \
+    --container-runtime=containerd \
+    --driver=${MINIKUBE_DRIVER} \
+    --kubernetes-version=${KIND_K8S_TAG} \
+    --cpus=4 \
+    --cni=flannel \
+    --extra-config="apiserver.runtime-config=resource.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha2=true" \
+    --extra-config="apiserver.feature-gates=${FEATURE_GATES}" \
+    --extra-config="scheduler.feature-gates=${FEATURE_GATES}" \
+    --extra-config="controller-manager.feature-gates=${FEATURE_GATES}" \
+    --extra-config="kubelet.feature-gates=${FEATURE_GATES}"
+
+# Enable CDI support in containerd and restart it
+${MINIKUBE} ssh "sudo sed -i '/\[plugins\.\"io\.containerd\.grpc\.v1\.cri\"]/a\    enable_cdi = true' /etc/containerd/config.toml"
+${MINIKUBE} ssh "sudo systemctl restart containerd"
+
+# If a driver image already exists, load it into the cluster
+EXISTING_IMAGE_ID="$(${CONTAINER_TOOL} images --filter "reference=${DRIVER_IMAGE}" --quiet)"
+if [ "${EXISTING_IMAGE_ID}" != "" ]; then
+    "${CURRENT_DIR}/../../scripts/load-driver-image-into-minikube.sh"
+fi
+
+set +x
+printf '\033[0;32m'
+echo "Cluster creation complete: ${MINIKUBE_CLUSTER_NAME}"
+printf '\033[0m'

--- a/demo/clusters/minikube/delete-cluster.sh
+++ b/demo/clusters/minikube/delete-cluster.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deletes the minikube cluster used by the demo.
+# See demo/scripts/common.sh for configuration (cluster name, etc.).
+
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/../../scripts/common.sh"
+
+${MINIKUBE} delete
+
+set +x
+printf '\033[0;32m'
+echo "Cluster deletion complete: ${MINIKUBE_CLUSTER_NAME}"
+printf '\033[0m'

--- a/demo/scripts/common.sh
+++ b/demo/scripts/common.sh
@@ -55,6 +55,12 @@ fi
 # The path to kind's cluster configuration file
 : ${KIND_CLUSTER_CONFIG_PATH:="${SCRIPTS_DIR}/kind-cluster-config.yaml"}
 
+# The name of the minikube cluster to create
+: ${MINIKUBE_CLUSTER_NAME:="${DRIVER_NAME}-cluster"}
+
+# The minikube VM/container driver (docker, podman, etc.)
+: ${MINIKUBE_DRIVER:="${CONTAINER_TOOL}"}
+
 # The derived name of the driver image to build
 : ${DRIVER_IMAGE:="${DRIVER_IMAGE_REGISTRY}/${DRIVER_IMAGE_NAME}:${DRIVER_IMAGE_TAG}"}
 
@@ -76,6 +82,7 @@ if [[ -z "${CONTAINER_TOOL}" ]]; then
 fi
 
 : ${KIND:="env KIND_EXPERIMENTAL_PROVIDER=${CONTAINER_TOOL} kind"}
+: ${MINIKUBE:="minikube --profile=${MINIKUBE_CLUSTER_NAME}"}
 
 # check_demo_config validates image-build env (DRIVER_IMAGE_OS/PLATFORM and
 # explicit PLATFORMS settings). Call from image build/push scripts only, after

--- a/demo/scripts/load-driver-image-into-minikube.sh
+++ b/demo/scripts/load-driver-image-into-minikube.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Loads the driver image into a running minikube cluster.
+
+CURRENT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+set -ex
+set -o pipefail
+
+source "${CURRENT_DIR}/common.sh"
+
+IMAGE_ARCHIVE=driver_image.tar
+${CONTAINER_TOOL} save -o "${IMAGE_ARCHIVE}" "${DRIVER_IMAGE}"
+${MINIKUBE} image load "${IMAGE_ARCHIVE}"
+rm "${IMAGE_ARCHIVE}"

--- a/test/e2e/setup-e2e-minikube.sh
+++ b/test/e2e/setup-e2e-minikube.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sets up a minikube cluster and installs prerequisites for e2e testing.
+# stop at first failure to save time
+set -e
+
+# Use local Helm chart by default, or from OCI registry if HELM_CHART_PATH is set
+# Example: HELM_CHART_PATH="oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver" make setup-e2e-minikube
+# The same env var is honored by the e2e tests themselves, which install a
+# per-test driver release at runtime.
+HELM_CHART_PATH="${HELM_CHART_PATH:-deployments/helm/dra-example-driver}"
+export HELM_CHART_PATH
+
+# Skip building local driver image if using OCI registry chart
+if [[ "${HELM_CHART_PATH}" != oci://* ]]; then
+    bash demo/build-driver.sh
+fi
+bash demo/clusters/minikube/create-cluster.sh
+
+helm upgrade -i \
+  --repo https://charts.jetstack.io \
+  --version v1.20.2 \
+  --create-namespace \
+  --namespace cert-manager \
+  --wait \
+  --set crds.enabled=true \
+  cert-manager \
+  cert-manager

--- a/test/e2e/teardown-e2e-minikube.sh
+++ b/test/e2e/teardown-e2e-minikube.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tears down the minikube cluster used for e2e testing.
+
+set -e
+
+bash demo/clusters/minikube/delete-cluster.sh


### PR DESCRIPTION
# Summary

This pull request adds end-to-end (e2e) testing support using **minikube** as an alternative to the existing kind-based setup. It introduces a GitHub Actions workflow to automatically run e2e tests on minikube, new Makefile targets for managing the minikube test lifecycle, cluster management scripts, and supporting demo utilities for loading images into minikube.

Fixes #195

P.S: Most of the initial implementation of minikube as provider is taken/inspired from @nestoracunablanco branch https://github.com/kubernetes-sigs/dra-example-driver/compare/main...nestoracunablanco:dra-example-driver:ci/e2eMinikubeWorkflow , but following GKE's pattern to better organise different provider specific code into their own dirs while keeping the common code in one place is followed additionally.

# Files Changed

📄 `.github/workflows/e2e-minikube.yaml`

New GitHub Actions workflow that runs e2e tests on minikube. Triggered on push and pull request events, it installs Go, checks out the code, builds the project, installs `helm`, `kubectl`, and `minikube`, then sequentially sets up, runs, and tears down the e2e test suite using the new Makefile targets.

---

📄 `Makefile`

Adds three new Makefile targets to manage the minikube-based e2e test lifecycle:
- `setup-e2e-minikube` — runs the minikube cluster setup script
- `test-e2e-minikube` — executes the Ginkgo e2e test suite with the `e2e` build tag
- `teardown-e2e-minikube` — runs the minikube cluster teardown script

---

📄 `demo/clusters/minikube/create-cluster.sh`

New script that creates a minikube cluster configured for DRA (Dynamic Resource Allocation) testing. It starts minikube with containerd, enables a comprehensive set of DRA-related feature gates across all components (apiserver, scheduler, controller-manager, kubelet), enables CDI support in containerd, and conditionally loads a pre-existing driver image into the cluster.

---

📄 `demo/clusters/minikube/delete-cluster.sh`

New script that tears down the minikube cluster used by the demo and e2e tests. Sources the shared configuration from `common.sh` and runs `minikube delete` against the configured cluster profile.

---

📄 `demo/scripts/common.sh`

Extends the shared configuration script with minikube-specific variables:
- `MINIKUBE_CLUSTER_NAME` — defaults to `<driver-name>-cluster`
- `MINIKUBE_DRIVER` — defaults to the value of `CONTAINER_TOOL`
- `MINIKUBE` — a convenience alias for `minikube --profile=<cluster-name>`

---

📄 `demo/scripts/load-driver-image-into-minikube.sh`

New utility script that loads the locally built driver image into a running minikube cluster. It exports the image as a tar archive using the configured container tool, loads it into minikube via `minikube image load`, then cleans up the temporary archive.

---

📄 `test/e2e/setup-e2e-minikube.sh`

New script that prepares the minikube environment for e2e testing. It optionally builds the local driver image (skipped when using an OCI registry chart), creates the minikube cluster, and installs `cert-manager` (v1.20.2) as a prerequisite via Helm. Supports overriding the Helm chart source via the `HELM_CHART_PATH` environment variable.

---

📄 `test/e2e/teardown-e2e-minikube.sh`

New script that tears down the minikube cluster after e2e testing completes by delegating to `demo/clusters/minikube/delete-cluster.sh`.