### PR TITLE
Add comment to explain why resetting a corrupt checkpoint is unsafe f…

### DIFF
--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -197,9 +197,17 @@ func (s *DeviceState) Unprepare(claimUID types.UID) error {
 	if err != nil {
 		// The checkpoint file exists but cannot be read or decoded. Return the
 		// error and let the kubelet retry rather than attempting any recovery.
-		// Writing a new checkpoint here would silently discard records of all
-		// other currently-prepared claims, and we cannot safely act on an
-		// unknown state.
+		//
+		// Deleting the file is not a way out: readCheckpoint treats a missing file
+		// as an empty checkpoint, so removing it writes off the records of every
+		// other prepared claim just as writing a new one would.
+		//
+		// This driver keeps only a prepared marker, because computeDeviceConfig
+		// rebuilds the CDI data from ResourceClaim.status.allocation and the
+		// devices this driver currently has. A fork that produces state during
+		// Prepare that it cannot rebuild afterwards, such as a MIG instance or a
+		// virtual function it later has to release, needs that state in the
+		// checkpoint for Unprepare to act on.
 		return fmt.Errorf("unable to read checkpoint: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does**
Adds an explanatory comment in `Unprepare()` next to the fail-closed checkpoint error path.

**Why**
While investigating a checkpoint-related panic https://github.com/kubernetes-sigs/dra-example-driver/pull/248, it came up that automatically resetting a corrupt checkpoint to empty might seem like a safe recovery — but it isn't, and the reason is subtle enough to trip up anyone forking this driver.

**The short version:** the kubelet does not re-call Prepare for already-running claims, only for new ones or after a node reboot. So if you wipe the checkpoint, it stays incomplete until the next reboot. For this example driver that is fine because `computeDeviceConfig` derives the device assignment purely from the claim spec — same input, same output, every time.

more info - https://github.com/kubernetes-sigs/dra-example-driver/issues/249. 