### PR TITLE
Add test for pod resources API- kep 3695

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ setup-e2e:
 	test/e2e/setup-e2e.sh
 
 test-e2e:
-	go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -p ./test/e2e/...
+	go run github.com/onsi/ginkgo/v2/ginkgo --tags=e2e -p $(GINKGO_FLAGS) ./test/e2e/...
 
 teardown-e2e:
 	test/e2e/teardown-e2e.sh

--- a/demo/examples/podresources-api/README.md
+++ b/demo/examples/podresources-api/README.md
@@ -1,0 +1,185 @@
+# PodResources API Example
+
+## Overview
+
+This example demonstrates how to query the kubelet **PodResources gRPC API** to discover DRA-allocated devices for running pods. This feature is part of [KEP-3695](https://github.com/kubernetes/enhancements/issues/3695), which extends the PodResources API to include resources allocated by DRA drivers.
+
+**Feature Status**:
+
+- **Beta** in Kubernetes 1.34
+- **Stable** in Kubernetes 1.36+
+
+**Setup**: One pod requesting a GPU through DRA, with options to query the PodResources API to see the allocated device.
+
+## Architecture
+
+```mermaid
+graph TD
+    Client["grpcurl\nList()"]
+
+    subgraph Node["Kubernetes Node"]
+        PRA["Kubelet\nPodResources API"]
+
+        subgraph WP["Pod"]
+            WC["Container"]
+        end
+        G1[["GPU"]]
+    end
+    WC --- G1
+
+    Client -->|"unix socket"| PRA
+    PRA -->|"dynamicResources:\n driverName, claimName\n deviceName, cdiDevices"| Client
+    PRA -.->|"reads allocation"| WC
+
+    style Node fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#000
+    style WP fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px,color:#000
+    style WC fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
+    style PRA fill:#fff9c4,stroke:#f9a825,stroke-width:2px,color:#000
+    style Client fill:#ffeaa7,stroke:#f9a825,stroke-width:2px,color:#000
+    style G1 fill:#9b59b6,color:#fff,stroke:#8e44ad,stroke-width:3px
+    linkStyle 0,1,2,3 stroke:#1a1a1a,stroke-width:2px
+```
+
+## Requirements
+
+### Cluster Requirements
+
+- **Kubernetes 1.34+** (Beta feature)
+- **Kubernetes 1.36+** (Stable, enabled by default)
+- For Kubernetes 1.34-1.35, ensure the feature gate is enabled (it's enabled by default in Beta)
+
+### Driver Requirements
+
+- **Profile**: `gpu` (default)
+- **GPUs**: 1 minimum
+
+## How to Run
+
+### 1. Install the Driver
+
+```bash
+helm upgrade -i \
+  --create-namespace \
+  --namespace dra-example-driver \
+  dra-example-driver \
+  deployments/helm/dra-example-driver
+```
+
+Expected output:
+
+```
+NAME: dra-example-driver
+LAST DEPLOYED: <date>
+NAMESPACE: dra-example-driver
+STATUS: deployed
+REVISION: 1
+DESCRIPTION: Install complete
+```
+
+### 2. Apply the Example
+
+```bash
+kubectl apply -f demo/examples/podresources-api/podresources-api.yaml
+```
+
+Expected output:
+
+```
+namespace/podresources-api created
+resourceclaimtemplate.resource.k8s.io/gpu-claim created
+pod/workload-pod created
+```
+
+### 3. Verify the Pod is Running
+
+```bash
+kubectl get pods -n podresources-api
+```
+
+Wait until `workload-pod` reaches `Running` state.
+
+### 4. Query the PodResources API
+
+For kind clusters, exec directly into the worker node container and query the socket from there. Because the kubelet gRPC server does not have reflection enabled, you must supply the proto file explicitly.
+
+> **Note**: Use `docker exec` instead of `podman exec` if your kind cluster uses Docker.
+
+```bash
+# Exec into the kind worker node
+podman exec -it dra-example-driver-cluster-worker bash
+
+# Inside the node: install grpcurl
+curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_x86_64.tar.gz \
+  | tar -xz -C /usr/local/bin grpcurl
+
+# Download the proto file
+mkdir -p /tmp/podresources
+curl -sSL https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.proto \
+  -o /tmp/podresources/api.proto
+
+# Query the API and filter for the workload pod
+grpcurl -plaintext \
+  -unix \
+  -import-path /tmp/podresources \
+  -proto /tmp/podresources/api.proto \
+  /var/lib/kubelet/pod-resources/kubelet.sock \
+  v1.PodResourcesLister/List | grep -A 25 "workload-pod"
+```
+
+---
+
+## Expected Output
+
+The PodResources API returns a JSON response containing all pods on the node. The `workload-pod` entry will show the DRA-allocated GPU under `dynamicResources`:
+
+```json
+{
+  "name": "workload-pod",
+  "namespace": "podresources-api",
+  "containers": [
+    {
+      "name": "workload",
+      "dynamicResources": [
+        {
+          "claimName": "workload-pod-gpu-<suffix>",
+          "claimNamespace": "podresources-api",
+          "claimResources": [
+            {
+              "cdiDevices": [
+                {
+                  "name": "k8s.gpu.example.com/gpu=common"
+                },
+                {
+                  "name": "k8s.gpu.example.com/gpu=<uuid>-gpu-0"
+                }
+              ],
+              "driverName": "gpu.example.com",
+              "poolName": "<node-name>",
+              "deviceName": "gpu-0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Key Fields Explained (KEP-3695)
+
+| Field                         | Description                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `dynamicResources`            | Array of DRA-allocated resources — new in KEP-3695; absent on pre-1.34 clusters                      |
+| `claimName`                   | Name of the `ResourceClaim` bound to the pod (includes a random suffix when created from a template) |
+| `claimNamespace`              | Namespace of the `ResourceClaim`                                                                     |
+| `claimResources[].driverName` | The DRA driver that allocated the device (e.g. `gpu.example.com`)                                    |
+| `claimResources[].poolName`   | The node the device lives on                                                                         |
+| `claimResources[].deviceName` | The allocated device ID (e.g. `gpu-0`)                                                               |
+| `claimResources[].cdiDevices` | CDI identifiers injected into the container environment                                              |
+
+## Cleanup
+
+```bash
+kubectl delete -f demo/examples/podresources-api/podresources-api.yaml
+helm uninstall dra-example-driver -n dra-example-driver
+```

--- a/demo/examples/podresources-api/podresources-api.yaml
+++ b/demo/examples/podresources-api/podresources-api.yaml
@@ -1,0 +1,45 @@
+# Example: Query PodResources API to see DRA-allocated devices
+# This example demonstrates KEP-3695 which extends the kubelet PodResources gRPC API
+# to include resources allocated by DRA drivers (Beta in 1.34, Stable in 1.36)
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podresources-api
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: podresources-api
+  name: gpu-claim
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.example.com
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: podresources-api
+  name: workload-pod
+  labels:
+    app: workload
+spec:
+  containers:
+  - name: workload
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["echo 'Workload running with DRA GPU'; export; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: gpu-claim
+

--- a/test/e2e/e2e_setup_test.go
+++ b/test/e2e/e2e_setup_test.go
@@ -46,14 +46,19 @@ import (
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
 )
 
-var rootDir, demoManifestsDir string
-var clientset *kubernetes.Clientset
-var dynamicClient dynamic.Interface
-var restMapper meta.RESTMapper
+var (
+	config                    *rest.Config
+	rootDir, demoManifestsDir string
+	clientset                 *kubernetes.Clientset
+	dynamicClient             dynamic.Interface
+	restMapper                meta.RESTMapper
+)
 
 // driverPodSelector finds kubelet plugin Pods within an installed driver's release namespace.
 const driverPodSelector = "app.kubernetes.io/component=kubeletplugin"
@@ -113,7 +118,8 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
+	var err error
+	config, err = kubeConfig.ClientConfig()
 	Expect(err).NotTo(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(config)
@@ -993,4 +999,135 @@ func verifyGPUConsumedCapacity(ctx context.Context, namespace, driverName string
 		g.Expect(seenShareIDs).To(HaveLen(len(pods.Items)),
 			"expected %d distinct ShareIDs, got %v", len(pods.Items), seenShareIDs)
 	}, checkPodLogsTimeout, checkPodLogsInterval).Should(Succeed())
+}
+
+// verifyPodResourcesAPI queries the kubelet PodResources API and verifies that
+// DRA-allocated devices are exposed (KEP-3695).
+func verifyPodResourcesAPI(ctx context.Context, namespace, podName, containerName, driverName string) {
+	GinkgoHelper()
+
+	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s/%s", namespace, podName)
+	nodeName := pod.Spec.NodeName
+	Expect(nodeName).NotTo(BeEmpty(), "Pod %s/%s has no node assigned", namespace, podName)
+
+	fmt.Fprintf(GinkgoWriter, "Querying PodResources API on node %s for pod %s/%s\n",
+		nodeName, namespace, podName)
+
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	Expect(err).NotTo(HaveOccurred(), "Failed to get server version")
+	k8sVersion := serverVersion.GitVersion
+	debugPodName := "podresources-debug-" + podName
+	hostPathDir := v1.HostPathDirectory
+
+	// Run grpcurl directly inside the container entrypoint
+	debugPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      debugPodName,
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			NodeName:      nodeName,
+			HostNetwork:   true,
+			HostPID:       true,
+			RestartPolicy: v1.RestartPolicyNever,
+			InitContainers: []v1.Container{
+				{
+					Name:  "download-proto",
+					Image: "curlimages/curl:latest",
+					Command: []string{
+						"sh", "-c",
+						fmt.Sprintf("mkdir -p /tmp/podresources && curl -sSL https://raw.githubusercontent.com/kubernetes/kubernetes/%s/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.proto -o /tmp/podresources/api.proto", k8sVersion),
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "proto-dir",
+							MountPath: "/tmp/podresources",
+						},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:  "query",
+					Image: "fullstorydev/grpcurl:latest",
+					Args: []string{
+						"-plaintext",
+						"-import-path", "/tmp/podresources",
+						"-proto", "/tmp/podresources/api.proto",
+						"unix:///var/lib/kubelet/pod-resources/kubelet.sock",
+						"v1.PodResourcesLister/List",
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: func() *bool { b := true; return &b }(),
+						RunAsUser:  ptr.To(int64(0)), // Force root user
+						RunAsGroup: ptr.To(int64(0)),
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "pod-resources",
+							MountPath: "/var/lib/kubelet/pod-resources",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "proto-dir",
+							MountPath: "/tmp/podresources",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "pod-resources",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/lib/kubelet/pod-resources",
+							Type: &hostPathDir,
+						},
+					},
+				},
+				{
+					Name: "proto-dir",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = clientset.CoreV1().Pods(namespace).Create(ctx, debugPod, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create debug pod")
+
+	DeferCleanup(func(cleanupCtx context.Context) {
+		deletePolicy := metav1.DeletePropagationForeground
+		err := clientset.CoreV1().Pods(namespace).Delete(cleanupCtx, debugPodName, metav1.DeleteOptions{
+			PropagationPolicy: &deletePolicy,
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			fmt.Fprintf(GinkgoWriter, "Warning: failed to delete debug pod %s/%s: %v\n",
+				namespace, debugPodName, err)
+		}
+	})
+	// Wait for the query pod to complete (Succeeded phase)
+	Eventually(func(g Gomega) {
+		p, err := clientset.CoreV1().Pods(namespace).Get(ctx, debugPodName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(p.Status.Phase).To(Equal(v1.PodSucceeded), "Debug pod failed or is still running")
+	}, "60s", "2s").Should(Succeed())
+
+	// Retrieve the pod logs to inspect the JSON output from grpcurl
+	req := clientset.CoreV1().Pods(namespace).GetLogs(debugPodName, &v1.PodLogOptions{})
+	logs, err := req.DoRaw(ctx)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get logs from debug pod")
+
+	output := string(logs)
+
+	// Validate KEP-3695 properties in the returned JSON
+	Expect(output).To(ContainSubstring(podName), "Target pod name missing from response")
+	Expect(output).To(ContainSubstring(containerName), "Target container name missing from response")
+	Expect(output).To(ContainSubstring("dynamicResources"), "Container has no dynamicResources")
+	Expect(output).To(ContainSubstring(driverName), "Driver %s not found under dynamicResources", driverName)
+
+	fmt.Fprintf(GinkgoWriter, "✓ PodResources API successfully verified via pod logs:\n%s\n", output)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -400,6 +400,22 @@ var _ = Describe("Test GPU allocation", func() {
 		Expect(shares[1].shareID).NotTo(BeEmpty(), "second allocation should have a ShareID")
 		Expect(shares[0].shareID).NotTo(Equal(shares[1].shareID), "shared allocations must have distinct ShareIDs")
 	})
+	It("should expose DRA resources via PodResources API", func(ctx SpecContext) {
+		drv := installDriver(ctx, DriverConfig{})
+		namespace := "podresources-api"
+		pods := []string{"workload-pod"}
+		containerName := "workload"
+		expectedGPUCount := 1
+
+		deployManifest(ctx, namespace, "podresources-api.yaml", drv)
+		checkPodsReadyAndRunning(ctx, namespace, pods)
+
+		observedGPUs := make(map[string]string)
+		verifyGPUAllocation(ctx, namespace, pods[0], containerName, expectedGPUCount, observedGPUs)
+
+		// Query PodResources API to verify DRA resources are exposed
+		verifyPodResourcesAPI(ctx, namespace, pods[0], containerName, drv.DriverName)
+	})
 
 	// Webhook tests share one driver pinned to "gpu.example.com" so their
 	// static testdata stays valid; Ordered+Serial avoids concurrent upgrades.


### PR DESCRIPTION
Fixes #186 

Adds an end-to-end test and accompanying demo that verifies the kubelet PodResources gRPC API correctly exposes DRA-allocated devices via the dynamicResources field introduced by [KEP-3695](https://github.com/kubernetes/enhancements/issues/3695).

Verification is done through a short-lived debug pod created on the same node as the workload. The debug pod uses two containers:

- curlimages/curl:latest (init container) — downloads api.proto from the Kubernetes v1.36.0 source into a shared EmptyDir volume. This is required because the kubelet gRPC server does not support server reflection.
- fullstorydev/grpcurl:latest (query container) — mounts the kubelet socket via a HostPath volume and calls v1.PodResourcesLister/List using the downloaded proto file via -import-path/-proto flags, running privileged as root to access the socket.

The response is captured from pod logs and asserted to contain the expected dynamicResources fields: pod name, container name, driver name, and claim name.

Assisted by: IBM Bob