### PR TITLE
fix: maintain device exclusivity by rejecting conflicting Prepare calls

### DIFF
--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -86,6 +86,16 @@ type DeviceState struct {
 
 	coreClient      coreclientset.Interface
 	gpuDeviceStatus bool
+
+	// preparedDevices tracks which claim currently holds each exclusively
+	// allocated device, so a Prepare call for a different claim can be
+	// rejected instead of silently double-booking it. This is in-memory only
+	// -- like all other driver state, it does not survive a restart, and
+	// device names are not persisted in the on-disk checkpoint (see
+	// PreparedClaim). Restart-time recovery of a claim's own devices is
+	// handled separately by restoreClaimFromCheckpoint, which is keyed by
+	// claim UID and never goes through this map.
+	preparedDevices map[string]types.UID
 }
 
 func NewDeviceState(config *Config) (*DeviceState, error) {
@@ -151,6 +161,7 @@ func NewDeviceState(config *Config) (*DeviceState, error) {
 		checkpointEncoder: checkpointEncoder,
 		coreClient:        config.coreclient,
 		gpuDeviceStatus:   config.flags.gpuDeviceStatus,
+		preparedDevices:   make(map[string]types.UID),
 	}
 
 	return state, nil
@@ -175,11 +186,16 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		return restoredDevices, nil
 	}
 
+	if err := s.checkDeviceExclusivity(claim); err != nil {
+		return nil, err
+	}
+
 	preparedDevices, err := s.prepareDevices(ctx, claim)
 	if err != nil {
 		return nil, fmt.Errorf("prepare failed: %v", err)
 	}
 	s.addClaimToCheckpoint(checkpoint, claim, preparedDevices)
+	s.recordPreparedDevices(claim)
 
 	if err = s.cdi.CreateClaimSpecFile(string(claim.UID), preparedDevices); err != nil {
 		return nil, fmt.Errorf("unable to create CDI spec file for claim: %v", err)
@@ -218,6 +234,7 @@ func (s *DeviceState) Unprepare(claimUID types.UID) error {
 		return fmt.Errorf("unprepare failed: %v", err)
 	}
 	s.removeClaimFromCheckpoint(checkpoint, claimUID)
+	s.releasePreparedDevices(claimUID)
 
 	err = s.cdi.DeleteClaimSpecFile(string(claimUID))
 	if err != nil {
@@ -403,6 +420,63 @@ func (s *DeviceState) checkAdminAccess(claim *resourceapi.ResourceClaim) bool {
 		}
 	}
 	return false
+}
+
+// checkDeviceExclusivity returns an error if any device claim was allocated
+// by this driver is already prepared for a different claim. Devices meant to
+// be shared by design -- AdminAccess allocations, and devices themselves
+// marked AllowMultipleAllocations (e.g. consumable-capacity/partitionable
+// devices) -- are excluded, since holding those concurrently is intended
+// behavior, not a conflict.
+func (s *DeviceState) checkDeviceExclusivity(claim *resourceapi.ResourceClaim) error {
+	for _, name := range s.exclusiveDeviceNames(claim) {
+		if holder, ok := s.preparedDevices[name]; ok && holder != claim.UID {
+			return fmt.Errorf("device %s is already prepared for claim %s", name, holder)
+		}
+	}
+	return nil
+}
+
+// recordPreparedDevices records that claim now holds each of its exclusively
+// allocated devices, for future checkDeviceExclusivity calls.
+func (s *DeviceState) recordPreparedDevices(claim *resourceapi.ResourceClaim) {
+	for _, name := range s.exclusiveDeviceNames(claim) {
+		s.preparedDevices[name] = claim.UID
+	}
+}
+
+// releasePreparedDevices removes claimUID's hold on any devices it was
+// tracked as holding.
+func (s *DeviceState) releasePreparedDevices(claimUID types.UID) {
+	for name, holder := range s.preparedDevices {
+		if holder == claimUID {
+			delete(s.preparedDevices, name)
+		}
+	}
+}
+
+// exclusiveDeviceNames returns the names of the devices claim was allocated
+// by this driver that are expected to be held exclusively -- i.e. excluding
+// AdminAccess allocations and devices that allow multiple concurrent
+// allocations, both of which are designed to be shared.
+func (s *DeviceState) exclusiveDeviceNames(claim *resourceapi.ResourceClaim) []string {
+	if claim == nil || claim.Status.Allocation == nil {
+		return nil
+	}
+	var names []string
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != s.driverName {
+			continue
+		}
+		if result.AdminAccess != nil && *result.AdminAccess {
+			continue
+		}
+		if device, ok := s.allocatable[result.Device]; ok && device.AllowMultipleAllocations != nil && *device.AllowMultipleAllocations {
+			continue
+		}
+		names = append(names, result.Device)
+	}
+	return names
 }
 
 func checkpointSerializer() (runtime.Decoder, runtime.Encoder, error) {

--- a/cmd/dra-example-kubeletplugin/state_test.go
+++ b/cmd/dra-example-kubeletplugin/state_test.go
@@ -398,6 +398,127 @@ func TestPrepareRestoredClaimFailsWhenClaimSpecCannotBeRecreated(t *testing.T) {
 	assert.Equal(t, claim.UID, checkpoint.PreparedClaims[0].UID)
 }
 
+// makeExclusive clears AllowMultipleAllocations on an already-registered
+// allocatable device, so tests can exercise the exclusivity check against a
+// device that is not, like the CPU profile's own numa nodes, shareable by
+// design.
+func makeExclusive(state *DeviceState, deviceName string) {
+	device := state.allocatable[deviceName]
+	device.AllowMultipleAllocations = nil
+	state.allocatable[deviceName] = device
+}
+
+// TestPrepareRejectsConflictingClaim verifies the fix for the double-allocation
+// race described in kubernetes/kubernetes#141471: if a claim's device is force-deleted,
+// the control plane can reallocate the same device to a second claim before the
+// first claim is unprepared. Prepare must reject the second claim rather than
+// silently double-booking the device.
+func TestPrepareRejectsConflictingClaim(t *testing.T) {
+	const (
+		nodeName   = "test-node"
+		driverName = "cpu.example.com"
+	)
+
+	root := t.TempDir()
+	state := newTestCPUDeviceState(t, root, nodeName, driverName)
+	makeExclusive(state, "numa-0")
+
+	claimA := testCPUClaim(driverName, nodeName)
+	claimA.UID, claimA.Name = "claim-a-uid", "claim-a"
+	_, err := state.Prepare(context.Background(), claimA)
+	require.NoError(t, err, "first claim should prepare successfully")
+
+	claimB := testCPUClaim(driverName, nodeName)
+	claimB.UID, claimB.Name = "claim-b-uid", "claim-b"
+	prepared, err := state.Prepare(context.Background(), claimB)
+	require.Error(t, err, "second claim for the same device must be rejected while the first is still prepared")
+	assert.Contains(t, err.Error(), "already prepared for claim")
+	assert.Nil(t, prepared)
+}
+
+// TestPrepareSucceedsAfterUnprepareReleasesDevice verifies the normal, non-racy
+// lifecycle still works: once a claim is unprepared, its device is free for a
+// different claim to prepare without conflict.
+func TestPrepareSucceedsAfterUnprepareReleasesDevice(t *testing.T) {
+	const (
+		nodeName   = "test-node"
+		driverName = "cpu.example.com"
+	)
+
+	root := t.TempDir()
+	state := newTestCPUDeviceState(t, root, nodeName, driverName)
+	makeExclusive(state, "numa-0")
+
+	claimA := testCPUClaim(driverName, nodeName)
+	claimA.UID, claimA.Name = "claim-a-uid", "claim-a"
+	_, err := state.Prepare(context.Background(), claimA)
+	require.NoError(t, err)
+
+	require.NoError(t, state.Unprepare(claimA.UID))
+
+	claimB := testCPUClaim(driverName, nodeName)
+	claimB.UID, claimB.Name = "claim-b-uid", "claim-b"
+	prepared, err := state.Prepare(context.Background(), claimB)
+	require.NoError(t, err, "device should be free once the original claim is unprepared")
+	assert.NotEmpty(t, prepared)
+}
+
+// TestPrepareIsIdempotentForSameClaim verifies that re-preparing the same claim
+// UID (e.g. a kubelet retry before the checkpoint write completed) is not
+// mistaken for a conflicting claim.
+func TestPrepareIsIdempotentForSameClaim(t *testing.T) {
+	const (
+		nodeName   = "test-node"
+		driverName = "cpu.example.com"
+	)
+
+	root := t.TempDir()
+	state := newTestCPUDeviceState(t, root, nodeName, driverName)
+	claim := testCPUClaim(driverName, nodeName)
+
+	_, err := state.Prepare(context.Background(), claim)
+	require.NoError(t, err)
+
+	// Same claim UID, no Unprepare in between -- must not be treated as a conflict.
+	_, err = state.Prepare(context.Background(), claim)
+	require.NoError(t, err)
+}
+
+// TestExclusiveDeviceNamesExcludesSharedAllocations verifies that AdminAccess
+// allocations and devices marked AllowMultipleAllocations are excluded from
+// exclusivity checking, since both are designed to be held concurrently by
+// multiple claims and must not be flagged as a conflict.
+func TestExclusiveDeviceNamesExcludesSharedAllocations(t *testing.T) {
+	const (
+		nodeName   = "test-node"
+		driverName = "cpu.example.com"
+	)
+
+	root := t.TempDir()
+	state := newTestCPUDeviceState(t, root, nodeName, driverName)
+	makeExclusive(state, "numa-0")
+	state.allocatable["shared-device"] = resourceapi.Device{
+		Name:                     "shared-device",
+		AllowMultipleAllocations: ptr.To(true),
+	}
+
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{UID: "claim-uid"},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{Results: []resourceapi.DeviceRequestAllocationResult{
+					{Request: "exclusive", Driver: driverName, Pool: nodeName, Device: "numa-0"},
+					{Request: "admin", Driver: driverName, Pool: nodeName, Device: "numa-0", AdminAccess: ptr.To(true)},
+					{Request: "shared", Driver: driverName, Pool: nodeName, Device: "shared-device"},
+				}},
+			},
+		},
+	}
+
+	names := state.exclusiveDeviceNames(claim)
+	assert.Equal(t, []string{"numa-0"}, names, "AdminAccess and AllowMultipleAllocations results must be excluded")
+}
+
 func newTestCPUDeviceState(t *testing.T, root, nodeName, driverName string) *DeviceState {
 	t.Helper()
 


### PR DESCRIPTION
Closes #263

*This PR was written in part with the assistance of generative AI.*

## What this PR does

`DeviceState.Prepare()` had no cross-claim exclusivity check: `prepareDevices`/
`computeDeviceConfig` only verified a requested device exists in the driver's static
`allocatable` set, never whether a *different* claim already holds it.

If a pod using a claim is force-deleted (`kubectl delete pod --grace-period=0 --force`, or the
identical mechanism `podgc` uses automatically after node loss), the control plane can deallocate
and reallocate the claim's device to a new claim before the original pod's container has actually
stopped on the node — [kubernetes/kubernetes#141471](https://github.com/kubernetes/kubernetes/issues/141471)
measured a real double-booking window of 1.52s-2.05s against this driver.

This adds `preparedDevices` tracking (device name → holding claim UID) and a
`checkDeviceExclusivity` call before preparing a new claim, rejecting it if a different claim
already holds one of its devices. `AdminAccess` allocations and devices marked
`AllowMultipleAllocations` are excluded from the check, since holding those concurrently is
intended behavior, not a conflict.

## Testing

4 new unit tests in `state_test.go`:
- `TestPrepareRejectsConflictingClaim` — the core fix
- `TestPrepareSucceedsAfterUnprepareReleasesDevice` — normal lifecycle unaffected
- `TestPrepareIsIdempotentForSameClaim` — same-claim retries still work
- `TestExclusiveDeviceNamesExcludesSharedAllocations` — `AdminAccess`/`AllowMultipleAllocations` filtering

Full existing test suite passes, no regressions (`go build ./...`, `go test ./...`, `go vet ./...`).

**Live-verified end to end** against a real cluster, re-running the original bug's repro against
this fix — both the two-manual-pods variant and the Deployment/ReplicaSet self-healing variant:

| | Double-booking window | Outcome |
|---|---|---|
| Before (manual pods) | 1.52s | Silent double-allocation |
| After (manual pods) | 0s | Rejected, then clean retry |
| Before (Deployment) | 2.05s | Silent double-allocation |
| After (Deployment) | 0s | Rejected, then clean retry |

Also verified the fix doesn't regress either legitimate sharing path:

| New claim | Device | Before | After |
|---|---|---|---|
| Ordinary | Dedicated | Double-booking (the bug) | **Exclusive** — rejected |
| Ordinary | Shared (`AllowMultipleAllocations`) | Sharing allowed | Same — unaffected |
| AdminAccess | Dedicated | Bypass allowed | Same — unaffected |
| AdminAccess | Shared | Bypass allowed | Same — unaffected |

<details>
<summary>Full logs and timestamps for all of the above</summary>

Manual pods, BEFORE:
```
10:04:09.853335  Preparing claim uid=24213d33... (pod-b)
10:04:09.856238  Returning newly prepared devices for claim uid=24213d33...   <-- succeeds immediately
10:04:11.377500  UnprepareResourceClaims called (pod-a's claim)              <-- 1.52s LATER
```

Manual pods, AFTER:
```
07:31:49.654726  Preparing claim uid=a02469a9... (pod-b)
07:31:49.655135  ERROR: device gpu-0 is already prepared for claim 15d84599...  <-- rejected immediately
07:31:51.086698  UnprepareResourceClaims called (pod-a's claim)
[kubelet retries automatically ~65s later, standard backoff]
                 pod-b: Running, 93s after the force-delete
```

Deployment (primary evidence, fully automatic ReplicaSet self-healing), BEFORE:
```
10:23:43.094250  Preparing claim uid=d3de7f10... (replacement pod)
10:23:43.100960  Returning newly prepared devices for claim uid=d3de7f10...   <-- succeeds immediately
10:23:45.147387  UnprepareResourceClaims called (original claim)             <-- 2.05s LATER
```
Measured 2.05s driver-level double-booking window, ≥1.61s confirmed container-level overlap —
the entire sequence fully automatic (ReplicaSet controller reacted in 79ms).

Deployment, AFTER:
```
07:35:34.150352  Preparing claim uid=00936167... (replacement pod)
07:35:34.150569  ERROR: device gpu-0 is already prepared for claim 7d3e5ab1...  <-- rejected immediately
07:35:35.998407  UnprepareResourceClaims called (original claim)
[kubelet retries automatically ~90s later, standard backoff]
                 pod: Running, 92s after the force-delete
```
Zero double-allocation window, fully automatic end to end, cleanly self-heals via kubelet's normal
retry once the real conflict clears — no deadlock, no manual intervention required.

Sharing-safety verification: with `gpuAllowMultipleAllocations=true`, two ordinary claims (16Gi
memory / 20 compute each, via the repo's own `gpu-allow-multiple-allocations` demo example) both
allocated and ran simultaneously on the same device. Separately, re-ran the DRA gap audit's
cross-tenant `AdminAccess` scenario (an ordinary exclusive claim in one namespace + an
`AdminAccess` claim in an admin-access-labeled namespace, both targeting the same device) against
this fix — both pods ran simultaneously, unaffected. Adding an `AdminAccess` claim on top of an
already-shared device (with its own small `capacity.requests`) also worked — all three pods ran
concurrently.

</details>
