### PR TITLE
Merge device status into ResourceClaim status.devices instead of replacing it

### DIFF
--- a/cmd/dra-example-kubeletplugin/state.go
+++ b/cmd/dra-example-kubeletplugin/state.go
@@ -37,6 +37,7 @@ import (
 
 	"k8s.io/klog/v2"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1"
+	"k8s.io/utils/ptr"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 
 	checkpointapi "sigs.k8s.io/dra-example-driver/internal/api/checkpoint"
@@ -506,9 +507,29 @@ func (s *DeviceState) updateDeviceStatus(ctx context.Context, ns, name string, d
 
 		// copy the object and update only status.devices
 		claim = claim.DeepCopy()
-		claim.Status.Devices = devices
+		claim.Status.Devices = mergeDeviceStatus(claim.Status.Devices, devices)
 
 		_, err = rc.UpdateStatus(ctx, claim, metav1.UpdateOptions{})
 		return err
 	})
+}
+
+// mergeDeviceStatus merges updates into existing per-device status entries,
+// matched on driver, pool, device and shareID. Only the Data field of a
+// matching entry is replaced, so fields written by other actors (for example
+// Conditions set by the binding conditions controller) are preserved. Entries
+// with no existing match are appended.
+func mergeDeviceStatus(existing, updates []resourceapi.AllocatedDeviceStatus) []resourceapi.AllocatedDeviceStatus {
+	merged := slices.Clone(existing)
+	for _, u := range updates {
+		idx := slices.IndexFunc(merged, func(d resourceapi.AllocatedDeviceStatus) bool {
+			return d.Driver == u.Driver && d.Pool == u.Pool && d.Device == u.Device && ptr.Equal(d.ShareID, u.ShareID)
+		})
+		if idx < 0 {
+			merged = append(merged, u)
+			continue
+		}
+		merged[idx].Data = u.Data
+	}
+	return merged
 }

--- a/cmd/dra-example-kubeletplugin/state_test.go
+++ b/cmd/dra-example-kubeletplugin/state_test.go
@@ -30,6 +30,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1"
 	"k8s.io/utils/ptr"
@@ -477,4 +478,41 @@ func assertClaimSpecResolvesPreparedDevices(t *testing.T, state *DeviceState, cl
 		}
 	}
 	assert.Greater(t, resolved, 0, "expected at least one claim-specific CDI device ID")
+}
+
+func TestMergeDeviceStatusPreservesConditions(t *testing.T) {
+	cond := metav1.Condition{Type: "BindingConditions", Status: metav1.ConditionTrue, Reason: "Ready"}
+	existing := []resourceapi.AllocatedDeviceStatus{
+		{Driver: "gpu.example.com", Pool: "node-a", Device: "gpu-0", Conditions: []metav1.Condition{cond}},
+	}
+	updates := []resourceapi.AllocatedDeviceStatus{
+		{Driver: "gpu.example.com", Pool: "node-a", Device: "gpu-0", Data: &runtime.RawExtension{Raw: []byte(`{"uuid":"x"}`)}},
+		{Driver: "gpu.example.com", Pool: "node-a", Device: "gpu-1", Data: &runtime.RawExtension{Raw: []byte(`{"uuid":"y"}`)}},
+	}
+
+	merged := mergeDeviceStatus(existing, updates)
+
+	require.Len(t, merged, 2)
+	assert.Equal(t, "gpu-0", merged[0].Device)
+	assert.Equal(t, []metav1.Condition{cond}, merged[0].Conditions, "existing conditions must be preserved")
+	assert.Equal(t, updates[0].Data, merged[0].Data)
+	assert.Equal(t, updates[1], merged[1], "unmatched entries are appended")
+	assert.Len(t, existing[0].Conditions, 1, "input must not be mutated")
+}
+
+func TestMergeDeviceStatusDistinguishesShareID(t *testing.T) {
+	shareA, shareB := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	existing := []resourceapi.AllocatedDeviceStatus{
+		{Driver: "gpu.example.com", Pool: "node-a", Device: "gpu-0", ShareID: &shareA, Conditions: []metav1.Condition{{Type: "BindingConditions", Status: metav1.ConditionTrue}}},
+	}
+	updates := []resourceapi.AllocatedDeviceStatus{
+		{Driver: "gpu.example.com", Pool: "node-a", Device: "gpu-0", ShareID: &shareB, Data: &runtime.RawExtension{Raw: []byte(`{}`)}},
+	}
+
+	merged := mergeDeviceStatus(existing, updates)
+
+	require.Len(t, merged, 2)
+	assert.Equal(t, &shareA, merged[0].ShareID)
+	assert.Len(t, merged[0].Conditions, 1)
+	assert.Equal(t, &shareB, merged[1].ShareID)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the kubelet plugin publishes per-device status (`--gpu-device-status`), `updateDeviceStatus` replaced the whole `ResourceClaim.status.devices` slice with entries that carry only `data`. That dropped the `BindingConditions=True` condition written earlier by the `BindingConditions` controller plugin, which then had to reconcile again to restore it.

This change merges the kubelet plugin's status into the existing per-device entries instead. Entries are matched on `driver`, `pool`, `device` and `shareID`; only `data` is replaced on a match, and unmatched entries are appended. Fields written by other actors, such as `conditions`, are left untouched.

Before, with both features enabled, one pod produced these claim revisions:

```
rv=1529  gpu-0{conditions=BindingConditions=True  data=false}   # controller sets condition
rv=1540  gpu-0{conditions=(none)                  data=true}    # kubelet plugin prepare wipes it
rv=1541  gpu-0{conditions=BindingConditions=True  data=true}    # controller re-adds it
```

After:

```
rv=2790  gpu-0{conditions=BindingConditions=True  data=false}   # controller sets condition
rv=2804  gpu-0{conditions=BindingConditions=True  data=true}    # kubelet plugin adds data, condition kept
```

#### Which issue(s) this PR fixes:

Fixes #266

#### Special notes for your reviewer:

Added unit tests for the merge helper:

- existing conditions are preserved when `data` is merged in, and unmatched devices are appended
- entries that differ only by `shareID` are treated as distinct

Tests run:

- `go test ./cmd/dra-example-kubeletplugin -count=1`
- `go test ./...`

Verified on a kind v1.37.0 cluster with `gpuDeviceStatus=true`, `kubeletPlugin.bindingConditions=true` and `controller.plugins={BindingConditions}`, running `demo/examples/binding-conditions`: the controller now logs `Set binding condition` once per claim instead of twice, and the final `status.devices` entry carries both the condition and the data.

AI usage disclosure: AI assistance (Claude Code) was used for testing and verifying the results, namely reproducing the issue on a kind cluster, capturing the ResourceClaim revisions before and after the change, and running the test suite.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the kubelet plugin overwriting `ResourceClaim.status.devices[].conditions` (for example the BindingConditions condition set by the controller) when publishing device status data.
```
