### PR TITLE
GPU profile: Publish standard pcieRoot device attribute

### DIFF
--- a/cmd/dra-example-kubeletplugin/main.go
+++ b/cmd/dra-example-kubeletplugin/main.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/cpu"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/gpu"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 	"sigs.k8s.io/dra-example-driver/internal/profiles/net"
 	"sigs.k8s.io/dra-example-driver/pkg/flags"
 	"sigs.k8s.io/dra-example-driver/pkg/metrics"
@@ -62,6 +63,9 @@ type Flags struct {
 	gpuDeviceStatus               bool
 	bindingConditions             bool
 	gpuAllowMultipleAllocations   bool
+	gpuPublishPCIeRoot            bool
+	netPublishPCIeRoot            bool
+	pcieRoots                     string
 	cpuNUMANodes                  int
 	cpusPerNUMANode               int
 }
@@ -76,13 +80,13 @@ type Config struct {
 
 var validProfiles = map[string]func(flags Flags) profiles.Profile{
 	gpu.ProfileName: func(flags Flags) profiles.Profile {
-		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions, flags.gpuDeviceStatus, flags.bindingConditions, flags.gpuAllowMultipleAllocations)
+		return gpu.NewProfile(flags.nodeName, flags.numDevices, flags.gpuPartitions, flags.gpuDeviceStatus, flags.bindingConditions, flags.gpuAllowMultipleAllocations, flags.gpuPublishPCIeRoot, helpers.ParsePCIeRoots(flags.pcieRoots))
 	},
 	cpu.ProfileName: func(flags Flags) profiles.Profile {
 		return cpu.NewProfile(flags.nodeName, flags.driverName, flags.cpuNUMANodes, flags.cpusPerNUMANode)
 	},
 	net.ProfileName: func(flags Flags) profiles.Profile {
-		return net.NewProfile(flags.nodeName, flags.numDevices)
+		return net.NewProfile(flags.nodeName, flags.numDevices, flags.netPublishPCIeRoot, helpers.ParsePCIeRoots(flags.pcieRoots))
 	},
 }
 
@@ -203,6 +207,24 @@ func newApp() *cli.App {
 			Usage:       "Allow GPU devices to be allocated to multiple DeviceRequests. Disabled by default.",
 			Destination: &flags.gpuAllowMultipleAllocations,
 			EnvVars:     []string{"GPU_ALLOW_MULTIPLE_ALLOCATIONS"},
+		},
+		&cli.BoolFlag{
+			Name:        "gpu-publish-pcie-root",
+			Usage:       "Publish resource.kubernetes.io/pcieRoot on mock GPU devices. Disabled by default.",
+			Destination: &flags.gpuPublishPCIeRoot,
+			EnvVars:     []string{"GPU_PUBLISH_PCIE_ROOT"},
+		},
+		&cli.BoolFlag{
+			Name:        "net-publish-pcie-root",
+			Usage:       "Publish resource.kubernetes.io/pcieRoot on mock net devices. Disabled by default.",
+			Destination: &flags.netPublishPCIeRoot,
+			EnvVars:     []string{"NET_PUBLISH_PCIE_ROOT"},
+		},
+		&cli.StringFlag{
+			Name:        "pcie-roots",
+			Usage:       "Comma-separated PCIe root values for mock devices (e.g. pci0000:00,pci0000:80). When publish is enabled and this is empty, deterministic defaults are used.",
+			Destination: &flags.pcieRoots,
+			EnvVars:     []string{"PCIE_ROOTS"},
 		},
 		&cli.IntFlag{
 			Name:        "cpu-numa-nodes",

--- a/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-example-driver/templates/kubeletplugin.yaml
@@ -90,6 +90,12 @@ spec:
           value: {{ .Values.gpuDeviceStatus | quote }}
         - name: GPU_ALLOW_MULTIPLE_ALLOCATIONS
           value: {{ .Values.gpuAllowMultipleAllocations | quote }}
+        - name: GPU_PUBLISH_PCIE_ROOT
+          value: {{ .Values.gpuPublishPCIeRoot | quote }}
+        - name: NET_PUBLISH_PCIE_ROOT
+          value: {{ .Values.netPublishPCIeRoot | quote }}
+        - name: PCIE_ROOTS
+          value: {{ .Values.pcieRoots | quote }}
         {{- if (gt (int .Values.kubeletPlugin.containers.plugin.healthcheckPort) 0) }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.plugin.healthcheckPort | quote }}

--- a/deployments/helm/dra-example-driver/values.yaml
+++ b/deployments/helm/dra-example-driver/values.yaml
@@ -39,6 +39,21 @@ gpuDeviceStatus: false
 # memory capacity (DRAConsumableCapacity feature).
 gpuAllowMultipleAllocations: false
 
+# gpuPublishPCIeRoot publishes resource.kubernetes.io/pcieRoot on mock GPU
+# devices. Enable for cross-driver matchAttribute demos (e.g. GPU + SR-IOV
+# Virtual Function alignment). Disabled by default.
+gpuPublishPCIeRoot: false
+
+# netPublishPCIeRoot publishes resource.kubernetes.io/pcieRoot on mock net
+# devices. Enable for cross-profile matchAttribute demos without SR-IOV.
+# Disabled by default.
+netPublishPCIeRoot: false
+
+# pcieRoots is a comma-separated list of PCIe root values assigned to mock
+# devices in round-robin order (e.g. "pci0000:00,pci0000:80"). When publish
+# is enabled and this is empty, defaults are used also in round-robin order.
+pcieRoots: ""
+
 imagePullSecrets: []
 image:
   repository: registry.k8s.io/dra-example-driver/dra-example-driver

--- a/internal/profiles/gpu/gpu.go
+++ b/internal/profiles/gpu/gpu.go
@@ -52,9 +52,11 @@ type Profile struct {
 	enableDeviceStatus       bool
 	bindingConditions        bool
 	allowMultipleAllocations bool
+	publishPCIeRoot          bool
+	pcieRoots                []string
 }
 
-func NewProfile(nodeName string, numGPUs int, partitionsPerGPU int, enableDeviceStatus bool, bindingConditions bool, allowMultipleAllocations bool) Profile {
+func NewProfile(nodeName string, numGPUs int, partitionsPerGPU int, enableDeviceStatus bool, bindingConditions bool, allowMultipleAllocations bool, publishPCIeRoot bool, pcieRoots []string) Profile {
 	return Profile{
 		nodeName:                 nodeName,
 		numGPUs:                  numGPUs,
@@ -62,10 +64,17 @@ func NewProfile(nodeName string, numGPUs int, partitionsPerGPU int, enableDevice
 		enableDeviceStatus:       enableDeviceStatus,
 		bindingConditions:        bindingConditions,
 		allowMultipleAllocations: allowMultipleAllocations,
+		publishPCIeRoot:          publishPCIeRoot,
+		pcieRoots:                pcieRoots,
 	}
 }
 
 func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
+	var pcieRoots []string
+	if p.publishPCIeRoot {
+		pcieRoots = helpers.ResolvePCIeRoots(p.pcieRoots)
+	}
+
 	seed := p.nodeName
 	uuids := generateUUIDs(seed, p.numGPUs)
 
@@ -95,6 +104,9 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 			"driverVersion": {
 				VersionValue: ptr.To("1.0.0"),
 			},
+		}
+		for k, v := range helpers.TopologyAttributesForDeviceIndex(i, pcieRoots) {
+			attrs[k] = v
 		}
 
 		if p.partitionsPerGPU > 0 {

--- a/internal/profiles/gpu/gpu_test.go
+++ b/internal/profiles/gpu/gpu_test.go
@@ -27,13 +27,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/dra-example-driver/internal/profiles"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 )
 
 func TestNewProfile(t *testing.T) {
-	profile := NewProfile("test-node", 4, 0, false, false, false)
+	profile := NewProfile("test-node", 4, 0, false, false, false, false, nil)
 
 	assert.Equal(t, "test-node", profile.nodeName)
 	assert.Equal(t, 4, profile.numGPUs)
@@ -41,20 +43,70 @@ func TestNewProfile(t *testing.T) {
 	assert.False(t, profile.enableDeviceStatus)
 	assert.Equal(t, false, profile.bindingConditions)
 	assert.Equal(t, false, profile.allowMultipleAllocations)
+	assert.False(t, profile.publishPCIeRoot)
 }
 
 func TestNewProfile_WithAllOptions(t *testing.T) {
-	profile := NewProfile("test-node", 2, 4, false, true, true)
+	roots := []string{"pci0000:00", "pci0000:80"}
+	profile := NewProfile("test-node", 2, 4, false, true, true, true, roots)
 
 	assert.Equal(t, "test-node", profile.nodeName)
 	assert.Equal(t, 2, profile.numGPUs)
 	assert.Equal(t, 4, profile.partitionsPerGPU)
 	assert.Equal(t, true, profile.bindingConditions)
 	assert.Equal(t, true, profile.allowMultipleAllocations)
+	assert.True(t, profile.publishPCIeRoot)
+	assert.Equal(t, roots, profile.pcieRoots)
+}
+
+func TestEnumerateDevices_PublishesPCIeRoot(t *testing.T) {
+	roots := []string{"pci0000:00", "pci0000:80"}
+	profile := NewProfile("test-node", 3, 0, false, false, false, true, roots)
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"gpu-0": roots[0],
+		"gpu-1": roots[1],
+		"gpu-2": roots[0],
+	}
+	for _, device := range resources.Pools["test-node"].Slices[0].Devices {
+		attr, ok := device.Attributes[deviceattribute.StandardDeviceAttributePCIeRoot]
+		require.True(t, ok, "device %q missing pcieRoot", device.Name)
+		require.NotNil(t, attr.StringValue)
+		assert.Equal(t, expected[device.Name], *attr.StringValue)
+	}
+}
+
+func TestEnumerateDevices_PublishesDefaultPCIeRoots(t *testing.T) {
+	profile := NewProfile("test-node", 2, 0, false, false, false, true, nil)
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"gpu-0": helpers.DefaultPCIeRoots[0],
+		"gpu-1": helpers.DefaultPCIeRoots[1],
+	}
+	for _, device := range resources.Pools["test-node"].Slices[0].Devices {
+		attr, ok := device.Attributes[deviceattribute.StandardDeviceAttributePCIeRoot]
+		require.True(t, ok, "device %q missing pcieRoot", device.Name)
+		assert.Equal(t, expected[device.Name], *attr.StringValue)
+	}
+}
+
+func TestEnumerateDevices_OmitsPCIeRootWhenDisabled(t *testing.T) {
+	profile := NewProfile("test-node", 2, 0, false, false, false, false, []string{"pci0000:00"})
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	for _, device := range resources.Pools["test-node"].Slices[0].Devices {
+		_, ok := device.Attributes[deviceattribute.StandardDeviceAttributePCIeRoot]
+		assert.False(t, ok, "device %q should not publish pcieRoot when disabled", device.Name)
+	}
 }
 
 func TestEnumerateDevices_Standard(t *testing.T) {
-	profile := NewProfile("test-node", 2, 0, false, false, false)
+	profile := NewProfile("test-node", 2, 0, false, false, false, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -107,7 +159,7 @@ func TestEnumerateDevices_Standard(t *testing.T) {
 }
 
 func TestEnumerateDevices_AllowMultipleAllocations(t *testing.T) {
-	profile := NewProfile("test-node", 1, 0, false, false, true)
+	profile := NewProfile("test-node", 1, 0, false, false, true, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -139,7 +191,7 @@ func TestEnumerateDevices_AllowMultipleAllocations(t *testing.T) {
 }
 
 func TestEnumerateDevices_Partitionable(t *testing.T) {
-	profile := NewProfile("test-node", 2, 4, false, false, false)
+	profile := NewProfile("test-node", 2, 4, false, false, false, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -185,7 +237,7 @@ func TestEnumerateDevices_Partitionable(t *testing.T) {
 }
 
 func TestEnumerateDevices_PartitionableDeviceAttributes(t *testing.T) {
-	profile := NewProfile("test-node", 1, 2, false, false, false)
+	profile := NewProfile("test-node", 1, 2, false, false, false, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -237,7 +289,7 @@ func TestEnumerateDevices_PartitionableDeviceAttributes(t *testing.T) {
 }
 
 func TestEnumerateDevices_AllowMultipleAllocations_AndPartitions(t *testing.T) {
-	profile := NewProfile("test-node", 1, 2, false, false, true)
+	profile := NewProfile("test-node", 1, 2, false, false, true, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -319,8 +371,8 @@ func TestEnumerateDevices_AllowMultipleAllocations_AndPartitions(t *testing.T) {
 
 func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
 	// UUIDs should be consistent for the same node name
-	profile1 := NewProfile("test-node", 2, 0, false, false, false)
-	profile2 := NewProfile("test-node", 2, 0, false, false, false)
+	profile1 := NewProfile("test-node", 2, 0, false, false, false, false, nil)
+	profile2 := NewProfile("test-node", 2, 0, false, false, false, false, nil)
 
 	resources1, err := profile1.EnumerateDevices()
 	require.NoError(t, err)
@@ -338,8 +390,8 @@ func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
 }
 
 func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
-	profile1 := NewProfile("node-1", 1, 0, false, false, false)
-	profile2 := NewProfile("node-2", 1, 0, false, false, false)
+	profile1 := NewProfile("node-1", 1, 0, false, false, false, false, nil)
+	profile2 := NewProfile("node-2", 1, 0, false, false, false, false, nil)
 
 	resources1, err := profile1.EnumerateDevices()
 	require.NoError(t, err)
@@ -353,9 +405,9 @@ func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
 }
 
 func TestBuildDeviceStatus_Disabled(t *testing.T) {
-	var _ profiles.DeviceStatusBuilder = NewProfile("test-node", 1, 0, true, false, false)
+	var _ profiles.DeviceStatusBuilder = NewProfile("test-node", 1, 0, true, false, false, false, nil)
 
-	profile := NewProfile("test-node", 1, 0, false, false, false)
+	profile := NewProfile("test-node", 1, 0, false, false, false, false, nil)
 	allocatable := map[string]resourceapi.Device{
 		"gpu-0": {Name: "gpu-0"},
 	}
@@ -370,7 +422,7 @@ func TestBuildDeviceStatus_Disabled(t *testing.T) {
 }
 
 func TestBuildDeviceStatus_Enabled(t *testing.T) {
-	profile := NewProfile("test-node", 1, 0, true, false, false)
+	profile := NewProfile("test-node", 1, 0, true, false, false, false, nil)
 	allocatable := map[string]resourceapi.Device{
 		"gpu-0": {
 			Name: "gpu-0",
@@ -406,7 +458,7 @@ func TestBuildDeviceStatus_Enabled(t *testing.T) {
 }
 
 func TestBuildDeviceStatus_UnknownDevice(t *testing.T) {
-	profile := NewProfile("test-node", 1, 0, true, false, false)
+	profile := NewProfile("test-node", 1, 0, true, false, false, false, nil)
 	result := &resourceapi.DeviceRequestAllocationResult{
 		Device: "gpu-0",
 		Driver: "gpu.example.com",
@@ -425,7 +477,7 @@ func TestBuildDeviceStatus_UnknownDevice(t *testing.T) {
 }
 
 func TestApplyConfig(t *testing.T) {
-	profile := NewProfile("test-node", 2, 0, false, false, false)
+	profile := NewProfile("test-node", 2, 0, false, false, false, false, nil)
 
 	tests := []struct {
 		name     string

--- a/internal/profiles/helpers/pcie_topology.go
+++ b/internal/profiles/helpers/pcie_topology.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import (
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/dynamic-resource-allocation/deviceattribute"
+)
+
+// DefaultPCIeRoots are used when pcieRoot publishing is enabled but no roots
+// are configured explicitly.
+var DefaultPCIeRoots = []string{"pci0000:00", "pci0000:80"}
+
+// ParsePCIeRoots splits a comma-separated list of PCIe root values.
+func ParsePCIeRoots(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var roots []string
+	for _, part := range strings.Split(s, ",") {
+		root := strings.TrimSpace(part)
+		if root != "" {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}
+
+// ResolvePCIeRoots returns configured roots when set, otherwise DefaultPCIeRoots.
+func ResolvePCIeRoots(configured []string) []string {
+	if len(configured) > 0 {
+		return configured
+	}
+	return DefaultPCIeRoots
+}
+
+// TopologyAttributesForDeviceIndex returns standard PCI topology attributes for
+// a mock device index. When roots is empty, nil is returned.
+func TopologyAttributesForDeviceIndex(index int, roots []string) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	if len(roots) == 0 {
+		return nil
+	}
+
+	pcieRoot := roots[index%len(roots)]
+	return map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+		deviceattribute.StandardDeviceAttributePCIeRoot: {
+			StringValue: &pcieRoot,
+		},
+	}
+}

--- a/internal/profiles/helpers/pcie_topology_test.go
+++ b/internal/profiles/helpers/pcie_topology_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/dynamic-resource-allocation/deviceattribute"
+)
+
+func TestParsePCIeRoots(t *testing.T) {
+	t.Run("empty string", func(t *testing.T) {
+		assert.Nil(t, ParsePCIeRoots(""))
+	})
+
+	t.Run("single root", func(t *testing.T) {
+		assert.Equal(t, []string{"pci0000:00"}, ParsePCIeRoots("pci0000:00"))
+	})
+
+	t.Run("comma separated with spaces", func(t *testing.T) {
+		assert.Equal(t, []string{"pci0000:00", "pci0000:80"}, ParsePCIeRoots("pci0000:00, pci0000:80"))
+	})
+
+	t.Run("skips empty parts", func(t *testing.T) {
+		assert.Equal(t, []string{"pci0000:00", "pci0000:80"}, ParsePCIeRoots("pci0000:00,,pci0000:80"))
+	})
+}
+
+func TestResolvePCIeRoots(t *testing.T) {
+	t.Run("returns configured roots", func(t *testing.T) {
+		configured := []string{"pci0000:40", "pci0000:c0"}
+		assert.Equal(t, configured, ResolvePCIeRoots(configured))
+	})
+
+	t.Run("returns defaults when empty", func(t *testing.T) {
+		assert.Equal(t, DefaultPCIeRoots, ResolvePCIeRoots(nil))
+		assert.Equal(t, DefaultPCIeRoots, ResolvePCIeRoots([]string{}))
+	})
+}
+
+func TestTopologyAttributesForDeviceIndex(t *testing.T) {
+	roots := []string{"pci0000:00", "pci0000:80"}
+
+	t.Run("nil when no roots", func(t *testing.T) {
+		assert.Nil(t, TopologyAttributesForDeviceIndex(0, nil))
+	})
+
+	t.Run("round robin roots", func(t *testing.T) {
+		attrs0 := TopologyAttributesForDeviceIndex(0, roots)
+		require.NotNil(t, attrs0)
+		assert.Equal(t, roots[0], *attrs0[deviceattribute.StandardDeviceAttributePCIeRoot].StringValue)
+
+		attrs1 := TopologyAttributesForDeviceIndex(1, roots)
+		require.NotNil(t, attrs1)
+		assert.Equal(t, roots[1], *attrs1[deviceattribute.StandardDeviceAttributePCIeRoot].StringValue)
+
+		attrs2 := TopologyAttributesForDeviceIndex(2, roots)
+		require.NotNil(t, attrs2)
+		assert.Equal(t, roots[0], *attrs2[deviceattribute.StandardDeviceAttributePCIeRoot].StringValue)
+	})
+}
+
+func TestTopologyAttributesForDeviceIndex_ResourceAPIKeys(t *testing.T) {
+	roots := []string{"pci0000:00"}
+	attrs := TopologyAttributesForDeviceIndex(0, roots)
+	require.Contains(t, attrs, resourceapi.QualifiedName(deviceattribute.StandardDeviceAttributePCIeRoot))
+}

--- a/internal/profiles/net/net.go
+++ b/internal/profiles/net/net.go
@@ -35,18 +35,27 @@ import (
 const ProfileName = "net"
 
 type Profile struct {
-	nodeName string
-	numNets  int
+	nodeName        string
+	numNets         int
+	publishPCIeRoot bool
+	pcieRoots       []string
 }
 
-func NewProfile(nodeName string, numNets int) Profile {
+func NewProfile(nodeName string, numNets int, publishPCIeRoot bool, pcieRoots []string) Profile {
 	return Profile{
-		nodeName: nodeName,
-		numNets:  numNets,
+		nodeName:        nodeName,
+		numNets:         numNets,
+		publishPCIeRoot: publishPCIeRoot,
+		pcieRoots:       pcieRoots,
 	}
 }
 
 func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
+	var pcieRoots []string
+	if p.publishPCIeRoot {
+		pcieRoots = helpers.ResolvePCIeRoots(p.pcieRoots)
+	}
+
 	seed := p.nodeName
 	uuids := helpers.GenerateUUIDs(seed, "net", p.numNets)
 
@@ -65,23 +74,28 @@ func (p Profile) EnumerateDevices() (resourceslice.DriverResources, error) {
 
 	var devices []resourceapi.Device
 	for i, uuid := range uuids {
+		attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+			"index": {
+				IntValue: ptr.To(int64(i)),
+			},
+			"uuid": {
+				StringValue: ptr.To(uuid),
+			},
+			"model": {
+				StringValue: ptr.To("LATEST-NET-MODEL"),
+			},
+			"driverVersion": {
+				VersionValue: ptr.To("1.0.0"),
+			},
+		}
+		for k, v := range helpers.TopologyAttributesForDeviceIndex(i, pcieRoots) {
+			attrs[k] = v
+		}
+
 		device := resourceapi.Device{
 			Name:                     fmt.Sprintf("nic-%d", i),
 			AllowMultipleAllocations: ptr.To(true),
-			Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				"index": {
-					IntValue: ptr.To(int64(i)),
-				},
-				"uuid": {
-					StringValue: ptr.To(uuid),
-				},
-				"model": {
-					StringValue: ptr.To("LATEST-NET-MODEL"),
-				},
-				"driverVersion": {
-					VersionValue: ptr.To("1.0.0"),
-				},
-			},
+			Attributes:               attrs,
 			Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
 				"vfs": {
 					Value: resource.MustParse("100"),

--- a/internal/profiles/net/net_test.go
+++ b/internal/profiles/net/net_test.go
@@ -24,20 +24,22 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/dra-example-driver/api/example.com/resource/net/v1alpha1"
+	"sigs.k8s.io/dra-example-driver/internal/profiles/helpers"
 )
 
 func TestNewProfile(t *testing.T) {
-	profile := NewProfile("test-node", 4)
+	profile := NewProfile("test-node", 4, false, nil)
 
 	assert.Equal(t, "test-node", profile.nodeName)
 	assert.Equal(t, 4, profile.numNets)
 }
 
 func TestEnumerateDevices(t *testing.T) {
-	profile := NewProfile("test-node", 3)
+	profile := NewProfile("test-node", 3, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -93,8 +95,54 @@ func TestEnumerateDevices(t *testing.T) {
 	}
 }
 
+func TestEnumerateDevices_PublishesPCIeRoot(t *testing.T) {
+	roots := []string{"pci0000:00", "pci0000:80"}
+	profile := NewProfile("test-node", 3, true, roots)
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"nic-0": roots[0],
+		"nic-1": roots[1],
+		"nic-2": roots[0],
+	}
+	for _, device := range resources.Pools["test-node"].Slices[0].Devices {
+		attr, ok := device.Attributes[deviceattribute.StandardDeviceAttributePCIeRoot]
+		require.True(t, ok, "device %q missing pcieRoot", device.Name)
+		require.NotNil(t, attr.StringValue)
+		assert.Equal(t, expected[device.Name], *attr.StringValue)
+	}
+}
+
+func TestEnumerateDevices_PublishesDefaultPCIeRoots(t *testing.T) {
+	profile := NewProfile("test-node", 2, true, nil)
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"nic-0": helpers.DefaultPCIeRoots[0],
+		"nic-1": helpers.DefaultPCIeRoots[1],
+	}
+	for _, device := range resources.Pools["test-node"].Slices[0].Devices {
+		attr, ok := device.Attributes[deviceattribute.StandardDeviceAttributePCIeRoot]
+		require.True(t, ok, "device %q missing pcieRoot", device.Name)
+		assert.Equal(t, expected[device.Name], *attr.StringValue)
+	}
+}
+
+func TestEnumerateDevices_OmitsPCIeRootWhenDisabled(t *testing.T) {
+	profile := NewProfile("test-node", 2, false, []string{"pci0000:00"})
+	resources, err := profile.EnumerateDevices()
+	require.NoError(t, err)
+
+	for _, device := range resources.Pools["test-node"].Slices[0].Devices {
+		_, ok := device.Attributes[deviceattribute.StandardDeviceAttributePCIeRoot]
+		assert.False(t, ok, "device %q should not publish pcieRoot when disabled", device.Name)
+	}
+}
+
 func TestEnumerateDevices_CapacityRequestPolicy(t *testing.T) {
-	profile := NewProfile("test-node", 1)
+	profile := NewProfile("test-node", 1, false, nil)
 
 	resources, err := profile.EnumerateDevices()
 	require.NoError(t, err)
@@ -130,8 +178,8 @@ func TestEnumerateDevices_CapacityRequestPolicy(t *testing.T) {
 
 func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
 	// UUIDs should be consistent for the same node name
-	profile1 := NewProfile("test-node", 2)
-	profile2 := NewProfile("test-node", 2)
+	profile1 := NewProfile("test-node", 2, false, nil)
+	profile2 := NewProfile("test-node", 2, false, nil)
 
 	resources1, err := profile1.EnumerateDevices()
 	require.NoError(t, err)
@@ -149,8 +197,8 @@ func TestEnumerateDevices_ConsistentUUIDs(t *testing.T) {
 }
 
 func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
-	profile1 := NewProfile("node-1", 1)
-	profile2 := NewProfile("node-2", 1)
+	profile1 := NewProfile("node-1", 1, false, nil)
+	profile2 := NewProfile("node-2", 1, false, nil)
 
 	resources1, err := profile1.EnumerateDevices()
 	require.NoError(t, err)
@@ -164,7 +212,7 @@ func TestEnumerateDevices_DifferentNodesHaveDifferentUUIDs(t *testing.T) {
 }
 
 func TestApplyConfig_Default(t *testing.T) {
-	profile := NewProfile("test-node", 2)
+	profile := NewProfile("test-node", 2, false, nil)
 	results := []*resourceapi.DeviceRequestAllocationResult{
 		{
 			Device: "nic-0",
@@ -186,7 +234,7 @@ func TestApplyConfig_Default(t *testing.T) {
 }
 
 func TestApplyConfig_WithBurstConfig(t *testing.T) {
-	profile := NewProfile("test-node", 2)
+	profile := NewProfile("test-node", 2, false, nil)
 	config := &configapi.NetConfig{
 		BandwidthBurst: &configapi.BandwidthBurstEntry{
 			// Burst values in bits - maximum amount of bits available instantaneously
@@ -221,7 +269,7 @@ func TestApplyConfig_WithBurstConfig(t *testing.T) {
 }
 
 func TestApplyConfig_MultipleDevices(t *testing.T) {
-	profile := NewProfile("test-node", 3)
+	profile := NewProfile("test-node", 3, false, nil)
 	results := []*resourceapi.DeviceRequestAllocationResult{
 		{
 			Device: "nic-0",
@@ -251,7 +299,7 @@ func TestApplyConfig_MultipleDevices(t *testing.T) {
 }
 
 func TestApplyConfig_WithShareID(t *testing.T) {
-	profile := NewProfile("test-node", 1)
+	profile := NewProfile("test-node", 1, false, nil)
 	results := []*resourceapi.DeviceRequestAllocationResult{
 		{
 			Device:  "nic-0",
@@ -273,7 +321,7 @@ func TestApplyConfig_WithShareID(t *testing.T) {
 }
 
 func TestValidate_ValidConfig(t *testing.T) {
-	profile := NewProfile("test-node", 1)
+	profile := NewProfile("test-node", 1, false, nil)
 	config := &configapi.NetConfig{
 		BandwidthBurst: &configapi.BandwidthBurstEntry{
 			IngressBurst: 10000000, // 10Mb in bits
@@ -286,7 +334,7 @@ func TestValidate_ValidConfig(t *testing.T) {
 }
 
 func TestValidate_InvalidConfigType(t *testing.T) {
-	profile := NewProfile("test-node", 1)
+	profile := NewProfile("test-node", 1, false, nil)
 
 	// Test with invalid config - BandwidthBurst should not be nil after normalization
 	config := &configapi.NetConfig{}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The DRA standard device attribute `resource.kubernetes.io/pcieRoot` lets schedulers and users express co-location constraints via `matchAttributes` (for example, allocate a GPU and a network device under the same PCIe root complex).

This PR adds optional, opt-in support for publishing that attribute on mock GPU and net devices in the example driver. Publishing is disabled by default and does not probe host topology; instead values are assigned deterministically in round-robin order from a configurable (or default) root list.

**Configuration**

| Flag / env var | Helm value | Default |
|---|---|---|
| `--gpu-publish-pcie-root` / `GPU_PUBLISH_PCIE_ROOT` | `gpuPublishPCIeRoot` | `false` |
| `--net-publish-pcie-root` / `NET_PUBLISH_PCIE_ROOT` | `netPublishPCIeRoot` | `false` |
| `--pcie-roots` / `PCIE_ROOTS` | `pcieRoots` | `""` |

When publishing is enabled and `PCIE_ROOTS` is empty, the driver uses built-in defaults (`pci0000:00`, `pci0000:80`). When set, roots are assigned in round-robin order (`gpu-0` → first root, `gpu-1` → second root, etc.).

**Motivation**

- Demonstrate cross-profile `matchAttributes` using only the example driver (GPU + net), without depending on other drivers.
- Allow external CI (for example, dra-driver-sriov) to override `PCIE_ROOTS` so mock GPU devices align with real SR-IOV VF topology on a given testbed.

Example: an SR-IOV VF publishes `resource.kubernetes.io/pcieRoot: pci0000:14`. With `gpuPublishPCIeRoot=true` and `pcieRoots="pci0000:14,..."`, a mock GPU can publish the same root so a `ResourceClaim` can match across drivers.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Publishing is opt-in per profile; existing deployments are unchanged.
- Assignment is configurable or defaults using round-robin.
- Shared helper logic lives in `internal/profiles/helpers/pcie_topology.go`.
- Unit tests cover configured roots, default roots, round-robin assignment, and the disabled-by-default behavior.

Tests run:

- `go test ./internal/profiles/helpers/... -count=1`
- `go test ./internal/profiles/gpu/... -count=1`
- `go test ./internal/profiles/net/... -count=1`
- `go test ./...`

#### Does this PR introduce a user-facing change?

```release-note
Added optional support for publishing the standard `resource.kubernetes.io/pcieRoot` device attribute on mock GPU and net devices. Enable via `GPU_PUBLISH_PCIE_ROOT` / `NET_PUBLISH_PCIE_ROOT`; override root values with `PCIE_ROOTS`. Disabled by default.